### PR TITLE
Subcommand Decorator and Type Annotation Syntax

### DIFF
--- a/examples/basic.py
+++ b/examples/basic.py
@@ -37,7 +37,7 @@ def ping(ctx):
 # (otherwise it's inferred from function name and docstring)
 # For more complex responses, return an Response object
 # You have to define the embed JSON manually (see API docs)
-# The "ctx" parameter is an InteractionContext object
+# The "ctx" parameter is an Context object
 # it works similarly to Context in Discord.py
 @discord.command(name="avatar", description="Show your user info")
 def _avatar(ctx):

--- a/examples/basic.py
+++ b/examples/basic.py
@@ -222,6 +222,30 @@ def search(ctx, subcommand, *, query):
         return f"https://yahoo.com/search?q={quoted}"
 
 
+# Alternatively, you can use a decorator syntax
+comic = discord.command_group("comic")
+
+
+@comic.command(options=[{
+    "name": "number",
+    "description": "Comic Number",
+    "type": CommandOptionType.INTEGER,
+    "required": True
+}])
+def xkcd(ctx, number):
+    return f"https://xkcd.com/{number}/"
+
+
+@comic.command(options=[{
+    "name": "number",
+    "description": "Comic Number",
+    "type": CommandOptionType.INTEGER,
+    "required": True
+}])
+def homestuck(ctx, number):
+    return f"https://homestuck.com/story/{number}"
+
+
 # Subcommand groups are also supported
 # Use ephemeral=True to only display the response to the user
 @discord.command(options=[

--- a/examples/basic.py
+++ b/examples/basic.py
@@ -2,7 +2,6 @@ import sys
 import os
 import threading
 import time
-import urllib.parse
 
 from flask import Flask
 
@@ -158,127 +157,36 @@ def homestuck(ctx, number: int):
     return f"https://homestuck.com/story/{number}"
 
 
-# You can define subcommands as options in the JSON as well
-# The subcommand name is received as a positional argument
-@discord.command(options=[
-    {
-        "name": "google",
-        "description": "Search with Google",
-        "type": CommandOptionType.SUB_COMMAND,
-        "options": [{
-            "name": "query",
-            "description": "Search query",
-            "type": CommandOptionType.STRING,
-            "required": True
-        }]
-    },
-    {
-        "name": "bing",
-        "description": "Search with Bing",
-        "type": CommandOptionType.SUB_COMMAND,
-        "options": [{
-            "name": "query",
-            "description": "Search query",
-            "type": CommandOptionType.STRING,
-            "required": True
-        }]
-    },
-    {
-        "name": "yahoo",
-        "description": "Search with Yahoo",
-        "type": CommandOptionType.SUB_COMMAND,
-        "options": [{
-            "name": "query",
-            "description": "Search query",
-            "type": CommandOptionType.STRING,
-            "required": True
-        }]
-    }
-])
-def search(ctx, subcommand, *, query):
-    "Search the Internet!"
-    quoted = urllib.parse.quote_plus(query)
-    if subcommand == "google":
-        return f"https://google.com/search?q={quoted}"
-    if subcommand == "bing":
-        return f"https://bing.com/search?q={quoted}"
-    if subcommand == "yahoo":
-        return f"https://yahoo.com/search?q={quoted}"
-
-
 # Subcommand groups are also supported
-# (for now, you have to provide the options JSON manually)
 # Use ephemeral=True to only display the response to the user
-@discord.command(options=[
-    {
-        "name": "to",
-        "description": "Convert a number into a certain base",
-        "type": CommandOptionType.SUB_COMMAND_GROUP,
-        "options": [
-            {
-                "name": "bin",
-                "description": "Convert a number to binary",
-                "type": CommandOptionType.SUB_COMMAND,
-                "options": [{
-                    "name": "number",
-                    "description": "The number to convert",
-                    "type": CommandOptionType.INTEGER
-                }]
-            },
-            {
-                "name": "hex",
-                "description": "Convert a number to hexadecimal",
-                "type": CommandOptionType.SUB_COMMAND,
-                "options": [{
-                    "name": "number",
-                    "description": "The number to convert",
-                    "type": CommandOptionType.INTEGER
-                }]
-            }
-        ]
-    },
-    {
-        "name": "from",
-        "description": "Convert a number to base 10",
-        "type": CommandOptionType.SUB_COMMAND_GROUP,
-        "options": [
-            {
-                "name": "bin",
-                "description": "Convert a number from binary",
-                "type": CommandOptionType.SUB_COMMAND,
-                "options": [{
-                    "name": "number",
-                    "description": "The number to convert",
-                    "type": CommandOptionType.STRING
-                }]
-            },
-            {
-                "name": "hex",
-                "description": "Convert a number from hexadecimal",
-                "type": CommandOptionType.SUB_COMMAND,
-                "options": [{
-                    "name": "number",
-                    "description": "The number to convert",
-                    "type": CommandOptionType.STRING
-                }]
-            }
-        ]
-    }
-])
-def base(ctx, command, subcommand, *, number):
-    "Convert a number between bases"
-    if command == "to":
-        if subcommand == "bin":
-            res = bin(number)[2:]
-        elif subcommand == "hex":
-            res = hex(number)[2:]
-    elif command == "from":
-        if subcommand == "bin":
-            res = str(int(number, base=2))
-        elif subcommand == "hex":
-            res = str(int(number, base=16))
+base = discord.command_group("base", "Convert a number between bases")
 
-    return InteractionResponse(f"Result: {res}", ephemeral=True)
+base_to = base.subgroup("to", "Convert a number into a certain base")
+base_from = base.subgroup("from", "Convert a number out of a certian base")
+
+
+@base_to.command(name="bin")
+def base_to_bin(ctx, number: int):
+    "Convert a number into binary"
+    return InteractionResponse(bin(number), ephemeral=True)
+
+
+@base_to.command(name="hex")
+def base_to_hex(ctx, number: int):
+    "Convert a number into hexadecimal"
+    return InteractionResponse(hex(number), ephemeral=True)
+
+
+@base_from.command(name="bin")
+def base_from_bin(ctx, number: str):
+    "Convert a number out of binary"
+    return InteractionResponse(int(number, base=2), ephemeral=True)
+
+
+@base_from.command(name="hex")
+def base_from_hex(ctx, number: str):
+    "Convert a number out of hexadecimal"
+    return InteractionResponse(int(number, base=16), ephemeral=True)
 
 
 # Create Blueprint objects to split functionality across modules

--- a/examples/basic.py
+++ b/examples/basic.py
@@ -5,11 +5,13 @@ import time
 
 from flask import Flask
 
+# This is just here for the sake of examples testing
+# (you don't actually need it in your code)
 sys.path.insert(1, ".")
 
 from flask_discord_interactions import (DiscordInteractions,  # noqa: E402
                                         DiscordInteractionsBlueprint,
-                                        InteractionResponse,
+                                        Response,
                                         CommandOptionType,
                                         Member, Role, Channel)
 
@@ -33,13 +35,13 @@ def ping(ctx):
 
 # You can specify a name and desc explicitly
 # (otherwise it's inferred from function name and docstring)
-# For more complex responses, return an InteractionResponse object
+# For more complex responses, return an Response object
 # You have to define the embed JSON manually (see API docs)
 # The "ctx" parameter is an InteractionContext object
 # it works similarly to Context in Discord.py
 @discord.command(name="avatar", description="Show your user info")
 def _avatar(ctx):
-    return InteractionResponse(embed={
+    return Response(embed={
         "title": ctx.author.display_name,
         "description": "Avatar Info",
         "fields": [
@@ -65,7 +67,7 @@ def _avatar(ctx):
 @discord.command(annotations={"message": "The message to repeat"})
 def repeat(ctx, message: str = "Hello!"):
     "Repeat the message (and escape mentions)"
-    return InteractionResponse(
+    return Response(
         f"{ctx.author.display_name} says {message}!",
         allowed_mentions={"parse": []},
     )
@@ -75,7 +77,7 @@ def repeat(ctx, message: str = "Hello!"):
 @discord.command(annotations={"user": "The user to show information about"})
 def avatar_of(ctx, user: Member):
     "Show someone else's user info"
-    return InteractionResponse(embed={
+    return Response(embed={
         "title": user.display_name,
         "description": "Avatar Info",
         "fields": [
@@ -105,7 +107,7 @@ def has_role(ctx, user: Member, role: Role):
 # Channel info, too!
 @discord.command()
 def channel_info(ctx, channel: Channel):
-    return InteractionResponse(embed={
+    return Response(embed={
         "title": channel.name,
         "description": channel.topic,
         "fields": [
@@ -140,7 +142,7 @@ def channel_info(ctx, channel: Channel):
 }])
 def favorite(ctx, choice):
     "What is your favorite animal?"
-    return InteractionResponse(f"{ctx.author.display_name} chooses {choice}!")
+    return Response(f"{ctx.author.display_name} chooses {choice}!")
 
 
 # You can use a decorator syntax to define subcommands
@@ -168,25 +170,25 @@ base_from = base.subgroup("from", "Convert a number out of a certian base")
 @base_to.command(name="bin")
 def base_to_bin(ctx, number: int):
     "Convert a number into binary"
-    return InteractionResponse(bin(number), ephemeral=True)
+    return Response(bin(number), ephemeral=True)
 
 
 @base_to.command(name="hex")
 def base_to_hex(ctx, number: int):
     "Convert a number into hexadecimal"
-    return InteractionResponse(hex(number), ephemeral=True)
+    return Response(hex(number), ephemeral=True)
 
 
 @base_from.command(name="bin")
 def base_from_bin(ctx, number: str):
     "Convert a number out of binary"
-    return InteractionResponse(int(number, base=2), ephemeral=True)
+    return Response(int(number, base=2), ephemeral=True)
 
 
 @base_from.command(name="hex")
 def base_from_hex(ctx, number: str):
     "Convert a number out of hexadecimal"
-    return InteractionResponse(int(number, base=16), ephemeral=True)
+    return Response(int(number, base=16), ephemeral=True)
 
 
 # Create Blueprint objects to split functionality across modules
@@ -214,7 +216,7 @@ def followup(ctx):
         ctx.edit("Editing my original message")
         time.sleep(5)
         print("Sending a file")
-        ctx.send(InteractionResponse(
+        ctx.send(Response(
             content="Sending a file",
             file=("README.md", open("README.md", "r"), "text/markdown")))
         time.sleep(5)
@@ -244,7 +246,7 @@ def delay(ctx, duration: int):
     thread = threading.Thread(target=do_delay)
     thread.start()
 
-    return InteractionResponse(deferred=True)
+    return Response(deferred=True)
 
 
 # Here's an invalid command just to test things out

--- a/flask_discord_interactions/__init__.py
+++ b/flask_discord_interactions/__init__.py
@@ -2,7 +2,7 @@ from .command import SlashCommand, SlashCommandSubgroup, SlashCommandGroup
 from .context import (InteractionContext, CommandOptionType, ChannelType,
                       Member, User, Role, Channel)
 from .discord import DiscordInteractions, DiscordInteractionsBlueprint
-from .response import InteractionResponse, InteractionResponseType
+from .response import Response, ResponseType
 
 
 __all__ = [
@@ -18,6 +18,6 @@ __all__ = [
     Channel,
     DiscordInteractions,
     DiscordInteractionsBlueprint,
-    InteractionResponse,
-    InteractionResponseType
+    Response,
+    ResponseType
 ]

--- a/flask_discord_interactions/__init__.py
+++ b/flask_discord_interactions/__init__.py
@@ -1,5 +1,5 @@
 from .command import SlashCommand, SlashCommandSubgroup, SlashCommandGroup
-from .context import (InteractionContext, CommandOptionType, ChannelType,
+from .context import (Context, CommandOptionType, ChannelType,
                       Member, User, Role, Channel)
 from .discord import DiscordInteractions, DiscordInteractionsBlueprint
 from .response import Response, ResponseType
@@ -9,7 +9,7 @@ __all__ = [
     SlashCommand,
     SlashCommandSubgroup,
     SlashCommandGroup,
-    InteractionContext,
+    Context,
     CommandOptionType,
     ChannelType,
     Member,

--- a/flask_discord_interactions/__init__.py
+++ b/flask_discord_interactions/__init__.py
@@ -1,17 +1,22 @@
 from .command import SlashCommand, SlashCommandGroup
-from .context import InteractionContext, CommandOptionType, ChannelType
+from .context import (InteractionContext, CommandOptionType, ChannelType,
+                      Member, User, Role, Channel)
 from .discord import DiscordInteractions, DiscordInteractionsBlueprint
-from .response import InteractionResponseType, InteractionResponse
+from .response import InteractionResponse, InteractionResponseType
 
 
 __all__ = [
-    CommandOptionType,
-    ChannelType,
     SlashCommand,
     SlashCommandGroup,
     InteractionContext,
+    CommandOptionType,
+    ChannelType,
+    Member,
+    User,
+    Role,
+    Channel,
     DiscordInteractions,
     DiscordInteractionsBlueprint,
-    InteractionResponseType,
-    InteractionResponse
+    InteractionResponse,
+    InteractionResponseType
 ]

--- a/flask_discord_interactions/__init__.py
+++ b/flask_discord_interactions/__init__.py
@@ -5,19 +5,27 @@ from .discord import DiscordInteractions, DiscordInteractionsBlueprint
 from .response import Response, ResponseType
 
 
+# deprecated names
+InteractionResponse = Response
+InteractionContext = Context
+
+
 __all__ = [
-    SlashCommand,
-    SlashCommandSubgroup,
-    SlashCommandGroup,
-    Context,
-    CommandOptionType,
-    ChannelType,
-    Member,
-    User,
-    Role,
-    Channel,
-    DiscordInteractions,
-    DiscordInteractionsBlueprint,
-    Response,
-    ResponseType
+    "SlashCommand",
+    "SlashCommandSubgroup",
+    "SlashCommandGroup",
+    "Context",
+    "CommandOptionType",
+    "ChannelType",
+    "Member",
+    "User",
+    "Role",
+    "Channel",
+    "DiscordInteractions",
+    "DiscordInteractionsBlueprint",
+    "Response",
+    "ResponseType",
+
+    "InteractionResponse",
+    "InteractionContext"
 ]

--- a/flask_discord_interactions/__init__.py
+++ b/flask_discord_interactions/__init__.py
@@ -1,4 +1,4 @@
-from .command import SlashCommand, SlashCommandGroup
+from .command import SlashCommand, SlashCommandSubgroup, SlashCommandGroup
 from .context import (InteractionContext, CommandOptionType, ChannelType,
                       Member, User, Role, Channel)
 from .discord import DiscordInteractions, DiscordInteractionsBlueprint
@@ -7,6 +7,7 @@ from .response import InteractionResponse, InteractionResponseType
 
 __all__ = [
     SlashCommand,
+    SlashCommandSubgroup,
     SlashCommandGroup,
     InteractionContext,
     CommandOptionType,

--- a/flask_discord_interactions/__init__.py
+++ b/flask_discord_interactions/__init__.py
@@ -1,4 +1,4 @@
-from .command import SlashCommand
+from .command import SlashCommand, SlashCommandGroup
 from .context import InteractionContext, CommandOptionType, ChannelType
 from .discord import DiscordInteractions, DiscordInteractionsBlueprint
 from .response import InteractionResponseType, InteractionResponse
@@ -8,6 +8,7 @@ __all__ = [
     CommandOptionType,
     ChannelType,
     SlashCommand,
+    SlashCommandGroup,
     InteractionContext,
     DiscordInteractions,
     DiscordInteractionsBlueprint,

--- a/flask_discord_interactions/command.py
+++ b/flask_discord_interactions/command.py
@@ -1,7 +1,7 @@
 import inspect
 import itertools
 
-from .context import (InteractionContext, CommandOptionType,
+from .context import (Context, CommandOptionType,
                       User, Member, Channel, Role)
 
 
@@ -60,7 +60,7 @@ class SlashCommand:
                 self.options.append(option)
 
     def make_context_and_run(self, discord, app, data):
-        context = InteractionContext(discord, app, data)
+        context = Context(discord, app, data)
         args, kwargs = context.create_args(
             data["data"], resolved=data["data"].get("resolved"))
         return self.run(context, *args, **kwargs)
@@ -115,7 +115,7 @@ class SlashCommandSubgroup(SlashCommand):
 
 class SlashCommandGroup(SlashCommandSubgroup):
     def make_context_and_run(self, discord, app, data):
-        context = InteractionContext(discord, app, data)
+        context = Context(discord, app, data)
         subcommands, kwargs = context.create_args(
             data["data"], resolved=data["data"].get("resolved"))
 

--- a/flask_discord_interactions/command.py
+++ b/flask_discord_interactions/command.py
@@ -1,4 +1,4 @@
-from .context import InteractionContext
+from .context import InteractionContext, CommandOptionType
 
 
 class SlashCommand:
@@ -8,8 +8,65 @@ class SlashCommand:
         self.description = description
         self.options = options
 
+        if self.name is None:
+            self.name = command.__name__
+        if self.description is None:
+            self.description = command.__doc__ or "No description"
+
+        if not 3 <= len(self.name) <= 32:
+            raise ValueError(
+                f"Error adding command {self.name}: "
+                "Command name must be between 3 and 32 characters.")
+        if not 1 <= len(self.description) <= 100:
+            raise ValueError(
+                f"Error adding command {self.name}: "
+                "Command description must be between 1 and 100 characters.")
+
     def run(self, discord, app, data):
         context = InteractionContext(discord, app, data)
         args, kwargs = context.create_args(
             data["data"], resolved=data["data"].get("resolved"))
         return self.command(context, *args, **kwargs)
+
+    def dump(self):
+        return {
+            "name": self.name,
+            "description": self.description,
+            "options": self.options
+        }
+
+
+class SlashCommandGroup(SlashCommand):
+    def __init__(self, name, description):
+        self.name = name
+        self.description = description
+        self.subcommands = {}
+
+    def command(self, name=None, description=None, options=[]):
+        "Decorator to create a subcommand"
+
+        def decorator(func):
+            nonlocal name, description, options
+            subcommand = SlashCommand(func, name, description, options)
+            self.subcommands[subcommand.name] = subcommand
+            return func
+
+        return decorator
+
+    def run(self, discord, app, data):
+        context = InteractionContext(discord, app, data)
+        subcommands, kwargs = context.create_args(
+            data["data"], resolved=data["data"].get("resolved"))
+
+        return self.subcommands[subcommands[0]].command(
+            context, *subcommands[1:], **kwargs)
+
+    @property
+    def options(self):
+        options = []
+        for command in self.subcommands.values():
+            data = command.dump()
+            data["type"] = CommandOptionType.SUB_COMMAND
+            options.append(data)
+
+        return options

--- a/flask_discord_interactions/context.py
+++ b/flask_discord_interactions/context.py
@@ -90,7 +90,7 @@ class Role:
             self.tags = data.get("tags", {})
 
 
-class InteractionContext:
+class Context:
     def __init__(self, discord, app, data=None):
         self.client_id = app.config["DISCORD_CLIENT_ID"]
         self.auth_headers = discord.auth_headers(app)

--- a/flask_discord_interactions/context.py
+++ b/flask_discord_interactions/context.py
@@ -24,7 +24,7 @@ class ChannelType:
     GUILD_STORE = 6
 
 
-class InteractionUser:
+class User:
     def __init__(self, data=None):
         if data:
             self.id = data.get("id")
@@ -49,7 +49,7 @@ class InteractionUser:
                 f"{self.id}/{self.avatar_hash}.png")
 
 
-class InteractionMember(InteractionUser):
+class Member(User):
     def __init__(self, data=None):
         if data:
             super().__init__(data["user"])
@@ -67,7 +67,7 @@ class InteractionMember(InteractionUser):
         return self.nick or self.username
 
 
-class InteractionChannel:
+class Channel:
     def __init__(self, data=None):
         if data:
             self.id = data.get("id")
@@ -76,7 +76,7 @@ class InteractionChannel:
             self.type = data.get("type")
 
 
-class InteractionRole:
+class Role:
     def __init__(self, data=None):
         if data:
             self.id = data.get("id")
@@ -96,7 +96,7 @@ class InteractionContext:
         self.auth_headers = discord.auth_headers(app)
 
         if data:
-            self.author = InteractionMember(data["member"])
+            self.author = Member(data["member"])
             self.id = data["id"]
             self.token = data["token"]
             self.channel_id = data["channel_id"]
@@ -112,12 +112,12 @@ class InteractionContext:
         for id in data.get("members", {}):
             member_info = data["members"][id]
             member_info["user"] = data["users"][id]
-            self.members[id] = InteractionMember(member_info)
+            self.members[id] = Member(member_info)
 
-        self.channels = {id: InteractionChannel(data)
+        self.channels = {id: Channel(data)
                          for id, data in data.get("channels", {}).items()}
 
-        self.roles = {id: InteractionRole(data)
+        self.roles = {id: Role(data)
                       for id, data in data.get("roles", {}).items()}
 
     def create_args(self, data, resolved):
@@ -138,12 +138,12 @@ class InteractionContext:
                 member_data = resolved["members"][option["value"]]
                 member_data["user"] = resolved["users"][option["value"]]
 
-                kwargs[option["name"]] = InteractionMember(member_data)
+                kwargs[option["name"]] = Member(member_data)
             elif option["type"] == CommandOptionType.CHANNEL:
-                kwargs[option["name"]] = InteractionChannel(
+                kwargs[option["name"]] = Channel(
                     resolved["channels"][option["value"]])
             elif option["type"] == CommandOptionType.ROLE:
-                kwargs[option["name"]] = InteractionRole(
+                kwargs[option["name"]] = Role(
                     resolved["roles"][option["value"]])
             else:
                 kwargs[option["name"]] = option["value"]

--- a/flask_discord_interactions/context.py
+++ b/flask_discord_interactions/context.py
@@ -1,6 +1,6 @@
 import requests
 
-from .response import InteractionResponse
+from .response import Response
 
 
 class CommandOptionType:
@@ -159,7 +159,7 @@ class InteractionContext:
         return url
 
     def edit(self, response, message="@original"):
-        response = InteractionResponse.from_return_value(response)
+        response = Response.from_return_value(response)
 
         response = requests.patch(
             self.followup_url(message),
@@ -176,7 +176,7 @@ class InteractionContext:
         response.raise_for_status()
 
     def send(self, response):
-        response = InteractionResponse.from_return_value(response)
+        response = Response.from_return_value(response)
 
         response = requests.post(
             self.followup_url(),

--- a/flask_discord_interactions/discord.py
+++ b/flask_discord_interactions/discord.py
@@ -168,7 +168,7 @@ class DiscordInteractions(DiscordInteractionsBlueprint):
         if slash_command is None:
             raise ValueError(f"Invalid command name: {slash_command}")
 
-        return slash_command.run(self, current_app, data)
+        return slash_command.make_context_and_run(self, current_app, data)
 
     def set_route(self, route, app=None):
         if app is None:

--- a/flask_discord_interactions/discord.py
+++ b/flask_discord_interactions/discord.py
@@ -8,7 +8,7 @@ from nacl.exceptions import BadSignatureError
 from nacl.signing import VerifyKey
 
 from .command import SlashCommand, SlashCommandGroup
-from .response import InteractionResponse, InteractionResponseType
+from .response import Response, ResponseType
 
 
 class InteractionType:
@@ -187,11 +187,11 @@ class DiscordInteractions(DiscordInteractionsBlueprint):
             if (request.json
                     and request.json.get("type") == InteractionType.PING):
                 return jsonify({
-                    "type": InteractionResponseType.PONG
+                    "type": ResponseType.PONG
                 })
 
             result = self.run_command(request.json)
 
-            response = InteractionResponse.from_return_value(result)
+            response = Response.from_return_value(result)
 
             return jsonify(response.dump())

--- a/flask_discord_interactions/response.py
+++ b/flask_discord_interactions/response.py
@@ -1,13 +1,13 @@
 import json
 
 
-class InteractionResponseType:
+class ResponseType:
     PONG = 1
     CHANNEL_MESSAGE_WITH_SOURCE = 4
     DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE = 5
 
 
-class InteractionResponse:
+class Response:
     def __init__(self, content=None, *, tts=False, embed=None, embeds=None,
                  allowed_mentions={"parse": ["roles", "users", "everyone"]},
                  deferred=False, ephemeral=False, file=None, files=None):
@@ -30,10 +30,10 @@ class InteractionResponse:
 
         if deferred:
             self.response_type = \
-                InteractionResponseType.DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE
+                ResponseType.DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE
         else:
             self.response_type = \
-                InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE
+                ResponseType.CHANNEL_MESSAGE_WITH_SOURCE
 
         self.flags = 64 if ephemeral else 0
 
@@ -45,11 +45,11 @@ class InteractionResponse:
     @staticmethod
     def from_return_value(result):
         if result is None:
-            return InteractionResponse()
-        elif isinstance(result, InteractionResponse):
+            return Response()
+        elif isinstance(result, Response):
             return result
         else:
-            return InteractionResponse(str(result))
+            return Response(str(result))
 
     def dump(self):
         return {


### PR DESCRIPTION
This PR makes some changes to the syntax for declaring subcommands and command parameters in order to bring it more in line with Discord.py.

### Subcommands

Old syntax:
```python
@discord.command(options=[
    {
        "name": "google",
        "description": "Search with Google",
        "type": CommandOptionType.SUB_COMMAND,
        "options": [{
            "name": "query",
            "description": "Search query",
            "type": CommandOptionType.STRING,
            "required": True
        }]
    },
    {
        "name": "bing",
        "description": "Search with Bing",
        "type": CommandOptionType.SUB_COMMAND,
        "options": [{
            "name": "query",
            "description": "Search query",
            "type": CommandOptionType.STRING,
            "required": True
        }]
    }
])
def search(ctx, subcommand, *, query):
    "Search the Internet!"
    quoted = urllib.parse.quote_plus(query)
    if subcommand == "google":
        return f"https://google.com/search?q={quoted}"
    if subcommand == "bing":
        return f"https://bing.com/search?q={quoted}"
```

New syntax:
```python
comic = discord.command_group("comic")


@comic.command()
def xkcd(ctx, number: int):
    return f"https://xkcd.com/{number}/"


@comic.command()
def homestuck(ctx, number: int):
    return f"https://homestuck.com/story/{number}"
```

### Command Parameters

Old syntax:
```python
@discord.command(options=[{
    "name": "channel",
    "description": "The channel to show information about",
    "type": CommandOptionType.CHANNEL,
    "required": True
}])
def channel_info(ctx, channel):
    return InteractionResponse("...")
```

New syntax:
```python
@discord.command(annotations={"channel": "The channel to show information about"})
def channel_info(ctx, channel: Channel):
    return Response(...)
```

## Renaming

Old names are (for now) being kept as aliases.

* `InteractionResponse` -> `Response`
* `InteractionContext` -> `Context`