### PR TITLE
Simple throttle to handle rate limiting during `update_slash_commands`

### DIFF
--- a/flask_discord_interactions/discord.py
+++ b/flask_discord_interactions/discord.py
@@ -154,9 +154,10 @@ class DiscordInteractions(DiscordInteractionsBlueprint):
         Args:
             response : requests response object
         """
+
+        rate_limit_remaining = int(response.headers["X-RateLimit-Remaining"])
+        rate_limit_reset = float(response.headers["X-RateLimit-Reset"])
         # rate_limit_limit = response.headers["X-RateLimit-Limit"]
-        rate_limit_remaining = response.headers["X-RateLimit-Remaining"]
-        rate_limit_reset = response.headers["X-RateLimit-Reset"]
         # rate_limit_bucket = response.headers["X-RateLimit-Bucket"]
 
         if (

--- a/flask_discord_interactions/discord.py
+++ b/flask_discord_interactions/discord.py
@@ -20,20 +20,18 @@ class DiscordInteractionsBlueprint:
     def __init__(self):
         self.discord_commands = {}
 
-    def add_slash_command(self, command, name=None,
-                          description=None, options=None, annotations=None):
-        slash_command = SlashCommand(
-            command, name, description, options, annotations)
+    def add_slash_command(
+        self, command, name=None, description=None, options=None, annotations=None
+    ):
+        slash_command = SlashCommand(command, name, description, options, annotations)
         self.discord_commands[slash_command.name] = slash_command
 
-    def command(self, name=None, description=None,
-                options=None, annotations=None):
+    def command(self, name=None, description=None, options=None, annotations=None):
         "Decorator to create a Slash Command"
 
         def decorator(func):
             nonlocal name, description, options
-            self.add_slash_command(
-                func, name, description, options, annotations)
+            self.add_slash_command(func, name, description, options, annotations)
             return func
 
         return decorator
@@ -67,25 +65,20 @@ class DiscordInteractions(DiscordInteractionsBlueprint):
             "https://discord.com/api/v8/oauth2/token",
             data={
                 "grant_type": "client_credentials",
-                "scope": "applications.commands.update"
+                "scope": "applications.commands.update",
             },
-            headers={
-                "Content-Type": "application/x-www-form-urlencoded"
-            },
-            auth=(
-                app.config["DISCORD_CLIENT_ID"],
-                app.config["DISCORD_CLIENT_SECRET"]
-            )
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+            auth=(app.config["DISCORD_CLIENT_ID"], app.config["DISCORD_CLIENT_SECRET"]),
         )
 
         response.raise_for_status()
         app.discord_token = response.json()
-        app.discord_token["expires_on"] = (time.time()
-                                           + app.discord_token["expires_in"]/2)
+        app.discord_token["expires_on"] = (
+            time.time() + app.discord_token["expires_in"] / 2
+        )
 
     def auth_headers(self, app):
-        if (app.discord_token is None
-                or time.time() > app.discord_token["expires_on"]):
+        if app.discord_token is None or time.time() > app.discord_token["expires_on"]:
             self.fetch_token(app)
         return {"Authorization": f"Bearer {app.discord_token['access_token']}"}
 
@@ -96,12 +89,16 @@ class DiscordInteractions(DiscordInteractionsBlueprint):
         needed = app.discord_commands.copy()
 
         if guild_id:
-            url = ("https://discord.com/api/v8/applications/"
-                   f"{app.config['DISCORD_CLIENT_ID']}/"
-                   f"guilds/{guild_id}/commands")
+            url = (
+                "https://discord.com/api/v8/applications/"
+                f"{app.config['DISCORD_CLIENT_ID']}/"
+                f"guilds/{guild_id}/commands"
+            )
         else:
-            url = ("https://discord.com/api/v8/applications/"
-                   f"{app.config['DISCORD_CLIENT_ID']}/commands")
+            url = (
+                "https://discord.com/api/v8/applications/"
+                f"{app.config['DISCORD_CLIENT_ID']}/commands"
+            )
 
         response = requests.get(url, headers=self.auth_headers(app))
         response.raise_for_status()
@@ -111,8 +108,11 @@ class DiscordInteractions(DiscordInteractionsBlueprint):
             if command["name"] in needed:
                 target = needed[command["name"]]
                 if command["description"] == target.description:
-                    if (not command.get("options") and not target.options
-                            or command.get("options") == target.options):
+                    if (
+                        not command.get("options")
+                        and not target.options
+                        or command.get("options") == target.options
+                    ):
                         del needed[command["name"]]
 
                         target.id = command["id"]
@@ -120,28 +120,52 @@ class DiscordInteractions(DiscordInteractionsBlueprint):
 
             id = command["id"]
             if guild_id:
-                delete_url = ("https://discord.com/api/v8/applications/"
-                              f"{app.config['DISCORD_CLIENT_ID']}/"
-                              f"guilds/{guild_id}/commands/{id}")
+                delete_url = (
+                    "https://discord.com/api/v8/applications/"
+                    f"{app.config['DISCORD_CLIENT_ID']}/"
+                    f"guilds/{guild_id}/commands/{id}"
+                )
             else:
                 delete_url = (
                     "https://discord.com/api/v8/applications/"
-                    f"{app.config['DISCORD_CLIENT_ID']}/commands/{id}")
+                    f"{app.config['DISCORD_CLIENT_ID']}/commands/{id}"
+                )
 
-            response = requests.delete(
-                delete_url, headers=self.auth_headers(app))
+            response = requests.delete(delete_url, headers=self.auth_headers(app))
             response.raise_for_status()
 
         for name, command in needed.items():
             response = requests.post(
-                url, json=command.dump(), headers=self.auth_headers(app))
+                url, json=command.dump(), headers=self.auth_headers(app)
+            )
+            self._throttle(response)
             try:
                 response.raise_for_status()
             except requests.exceptions.HTTPError:
                 raise ValueError(
                     f"Unable to register command {command.name}\n"
-                    f"{response.status_code} {response.text}")
+                    f"{response.status_code} {response.text}"
+                )
             command.id = response.json()["id"]
+
+    def _throttle(self, response):
+        """throttle the number of posts made
+        see discord rate limits here https://discord.com/developers/docs/topics/rate-limits
+        Args:
+            response : requests response object
+        """
+        # rate_limit_limit = response.headers["X-RateLimit-Limit"]
+        rate_limit_remaining = response.headers["X-RateLimit-Remaining"]
+        rate_limit_reset = response.headers["X-RateLimit-Reset"]
+        # rate_limit_bucket = response.headers["X-RateLimit-Bucket"]
+
+        if (
+            rate_limit_remaining == 0
+        ):  # if rate limit hits zero pause until rate limit epoch has passed
+            while (
+                time.time() < rate_limit_reset
+            ):  # compare current epoch time against reset epoch time
+                time.sleep(1)
 
     def register_blueprint(self, blueprint, app=None):
         if app is None:
@@ -151,8 +175,7 @@ class DiscordInteractions(DiscordInteractionsBlueprint):
 
     def verify_signature(self, data, signature, timestamp):
         message = timestamp.encode() + data
-        verify_key = VerifyKey(
-            bytes.fromhex(current_app.config["DISCORD_PUBLIC_KEY"]))
+        verify_key = VerifyKey(bytes.fromhex(current_app.config["DISCORD_PUBLIC_KEY"]))
         try:
             verify_key.verify(message, bytes.fromhex(signature))
         except BadSignatureError:
@@ -176,19 +199,18 @@ class DiscordInteractions(DiscordInteractionsBlueprint):
 
         @app.route(route, methods=["POST"])
         def interactions():
-            signature = request.headers.get('X-Signature-Ed25519')
-            timestamp = request.headers.get('X-Signature-Timestamp')
+            signature = request.headers.get("X-Signature-Ed25519")
+            timestamp = request.headers.get("X-Signature-Timestamp")
 
-            if (signature is None or timestamp is None
-                    or not self.verify_signature(
-                    request.data, signature, timestamp)):
+            if (
+                signature is None
+                or timestamp is None
+                or not self.verify_signature(request.data, signature, timestamp)
+            ):
                 return "Bad Request Signature", 401
 
-            if (request.json
-                    and request.json.get("type") == InteractionType.PING):
-                return jsonify({
-                    "type": ResponseType.PONG
-                })
+            if request.json and request.json.get("type") == InteractionType.PING:
+                return jsonify({"type": ResponseType.PONG})
 
             result = self.run_command(request.json)
 


### PR DESCRIPTION
This PR addresses issue #4 . It's a simple throttle that uses the returned header values `X-RateLimit-Remaining` and `X-RateLimit-Reset` that just goes into a loop until current epoch time is greater than ``X-RateLimit-Reset`

The meat and potatoes of it are on lines 141 and 151-170. I apologize for my formatter (Black) autoformatting everything thus creating a bunch of insertions and deletions. This may not be the most elegant solution but I've tested it on my end and I'm able to get more than 2 discord commands registered as where before I couldn't. Even if you don't accept the PR I hope it helps. Here's a link to the relevant docs from discord https://discord.com/developers/docs/topics/rate-limits

-Brad