### PR TITLE
Allow providing choices for an option using Enums

### DIFF
--- a/examples/context.py
+++ b/examples/context.py
@@ -6,7 +6,7 @@ from flask import Flask
 sys.path.insert(1, ".")
 
 from flask_discord_interactions import (DiscordInteractions,  # noqa: E402
-                                        Response, Member, Role, Channel)
+                                        Response)
 
 
 app = Flask(__name__)
@@ -19,13 +19,13 @@ app.config["DISCORD_CLIENT_SECRET"] = os.environ["DISCORD_CLIENT_SECRET"]
 discord.update_slash_commands()
 
 
-# For more complex responses, return an Response object
-# You have to define the embed JSON manually for now (see API docs)
 # The "ctx" parameter is an Context object
 # it works similarly to Context in Discord.py
 @discord.command()
 def avatar(ctx):
     "Show your user info"
+
+    # You have to define the embed JSON manually for now (see API docs)
     return Response(embed={
         "title": ctx.author.display_name,
         "description": "Avatar Info",
@@ -42,54 +42,17 @@ def avatar(ctx):
             {
                 "name": "User ID",
                 "value": ctx.author.id
+            },
+            {
+                "name": "Channel ID",
+                "value": ctx.channel_id
+            },
+            {
+                "name": "Guild ID",
+                "value": ctx.guild_id
             }
         ],
         "image": {"url": ctx.author.avatar_url}
-    })
-
-
-# For User, Channel, and Role options, your function is passed an object
-# that provides information about the resource
-# You can access data about users with the context object
-@discord.command(annotations={"user": "The user to show information about"})
-def avatar_of(ctx, user: Member):
-    "Show someone else's user info"
-    return Response(embed={
-        "title": user.display_name,
-        "description": "Avatar Info",
-        "fields": [
-            {
-                "name": "Username",
-                "value": (f"**{user.username}**"
-                          f"#{user.discriminator}")
-            },
-            {
-                "name": "User ID",
-                "value": user.id
-            }
-        ],
-        "image": {"url": user.avatar_url}
-    })
-
-
-@discord.command()
-def has_role(ctx, user: Member, role: Role):
-    if role.id in user.roles:
-        return f"Yes, user {user.display_name} has role {role.name}."
-    else:
-        return f"No, user {user.display_name} does not have role {role.name}."
-
-
-@discord.command()
-def channel_info(ctx, channel: Channel):
-    return Response(embed={
-        "title": channel.name,
-        "fields": [
-            {
-                "name": "Channel ID",
-                "value": channel.id
-            }
-        ]
     })
 
 

--- a/examples/options.py
+++ b/examples/options.py
@@ -1,12 +1,13 @@
 import os
 import sys
+import enum
 
 from flask import Flask
 
 sys.path.insert(1, ".")
 
 from flask_discord_interactions import (DiscordInteractions,  # noqa: E402
-                                        Response, CommandOptionType)
+                                        Response)
 
 
 app = Flask(__name__)
@@ -20,6 +21,8 @@ discord.update_slash_commands()
 
 
 # To specify options, include them with type annotations, just like Discord.py
+# The annotations dict is used to provide a description for each option
+# (they default to "no description")
 @discord.command(annotations={"message": "The message to repeat"})
 def repeat(ctx, message: str = "Hello!"):
     "Repeat the message (and escape mentions)"
@@ -29,26 +32,38 @@ def repeat(ctx, message: str = "Hello!"):
     )
 
 
-# Define choices in the options JSON, see Discord API docs for details
-@discord.command(options=[{
-    "name": "choice",
-    "description": "Your favorite animal",
-    "type": CommandOptionType.STRING,
-    "required": True,
-    "choices": [
-        {
-            "name": "Dog",
-            "value": "dog"
-        },
-        {
-            "name": "Cat",
-            "value": "cat"
-        }
-    ]
-}])
-def favorite(ctx, choice):
+# For using the "choices" field, you can use an Enum
+class Animal(enum.Enum):
+    Dog = "dog"
+    Cat = "cat"
+
+
+@discord.command(annotations={"choice": "Your favorite animal"})
+def favorite(ctx, choice: Animal):
     "What is your favorite animal?"
-    return Response(f"{ctx.author.display_name} chooses {choice}!")
+    return f"{ctx.author.display_name} chooses {choice}!"
+
+
+# This is also handy if you want to use the same options across multiple
+# commands
+@discord.command(annotations={"choice": "The animal you hate the most"})
+def hate(ctx, choice: Animal):
+    "What is the animal you hate the most?"
+    return f"{ctx.author.display_name} hates {choice}s."
+
+
+# You can also use IntEnum to receive the value as an integer
+class BigNumber(enum.IntEnum):
+    thousand = 1_000
+    million = 1_000_000
+    billion = 1_000_000_000
+    trillion = 1_000_000_000_000
+
+
+@discord.command(annotations={"number": "A big number"})
+def big_number(ctx, number: BigNumber):
+    "Print out a large number"
+    return f"One more than the number is {number+1}."
 
 
 discord.set_route("/interactions")

--- a/examples/options.py
+++ b/examples/options.py
@@ -7,7 +7,7 @@ from flask import Flask
 sys.path.insert(1, ".")
 
 from flask_discord_interactions import (DiscordInteractions,  # noqa: E402
-                                        Response)
+                                        Response, Member, Channel, Role)
 
 
 app = Flask(__name__)
@@ -30,6 +30,17 @@ def repeat(ctx, message: str = "Hello!"):
         f"{ctx.author.display_name} says {message}!",
         allowed_mentions={"parse": []},
     )
+
+
+# You can use str, int, or bool
+@discord.command()
+def add_one(ctx, number: int):
+    return Response(str(number + 1), ephemeral=True)
+
+
+@discord.command()
+def and_gate(ctx, a: bool, b: bool):
+    return f"{a} AND {b} is {a and b}"
 
 
 # For using the "choices" field, you can use an Enum
@@ -64,6 +75,51 @@ class BigNumber(enum.IntEnum):
 def big_number(ctx, number: BigNumber):
     "Print out a large number"
     return f"One more than the number is {number+1}."
+
+
+# For User, Channel, and Role options, your function is passed an object
+# that provides information about the resource
+# You can access data about users with the context object
+@discord.command(annotations={"user": "The user to show information about"})
+def avatar_of(ctx, user: Member):
+    "Show someone else's user info"
+    return Response(embed={
+        "title": user.display_name,
+        "description": "Avatar Info",
+        "fields": [
+            {
+                "name": "Username",
+                "value": (f"**{user.username}**"
+                          f"#{user.discriminator}")
+            },
+            {
+                "name": "User ID",
+                "value": user.id
+            }
+        ],
+        "image": {"url": user.avatar_url}
+    })
+
+
+@discord.command()
+def has_role(ctx, user: Member, role: Role):
+    if role.id in user.roles:
+        return f"Yes, user {user.display_name} has role {role.name}."
+    else:
+        return f"No, user {user.display_name} does not have role {role.name}."
+
+
+@discord.command()
+def channel_info(ctx, channel: Channel):
+    return Response(embed={
+        "title": channel.name,
+        "fields": [
+            {
+                "name": "Channel ID",
+                "value": channel.id
+            }
+        ]
+    })
 
 
 discord.set_route("/interactions")


### PR DESCRIPTION
This PR allows users to provide an Enum as a type annotation to indicate that a Slash Command option should only have limited choices. It replaces the old syntax:

```python
@discord.command(options=[{
    "name": "choice",
    "description": "Your favorite animal",
    "type": CommandOptionType.STRING,
    "required": True,
    "choices": [
        {
            "name": "Dog",
            "value": "dog"
        },
        {
            "name": "Cat",
            "value": "cat"
        }
    ]
}])
def favorite(ctx, choice):
    ...
```

with this new syntax:

```python
class Animal(enum.Enum):
    Dog = "dog"
    Cat = "cat"


@discord.command(annotations={"choice": "Your favorite animal"})
def favorite(ctx, choice: Animal):
    ...
```

This change means that almost all use-cases of the `options` parameter can be done with type annotations instead.