### PR TITLE
Add Examples To Docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,5 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+.vscode/

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -7,4 +7,5 @@ API Reference
     discord.rst
     command.rst
     context.rst
+    options.rst
     response.rst

--- a/docs/command.rst
+++ b/docs/command.rst
@@ -1,13 +1,122 @@
+.. _command-page:
+
 Command
 =======
+
+In Flask-Discord-Interactions, commands are created with a declarative syntax
+that should be familiar to users of Discord.py.
+
+Slash Commands
+--------------
+
+Commands are created using the :meth:`.DiscordInteractions.command`
+decorator.
+
+Here is a basic command:
+
+.. code-block:: python
+
+    @discord.command()
+    def ping(ctx):
+        "Respond with a friendly 'pong'!"
+        return "Pong!"
+
+The ``ctx`` parameter is a :class:`.Context` object.
+For more information about it, see :ref:`context-page`.
+
+Options can be provided as parameters to this command. See
+:ref:`options-page` for details.
+
+The function must return either a string or a
+:class:`.Response` object. For
+more information about what kind of responses are valid, see
+:ref:`response-page`.
+
+Full API
+^^^^^^^^
 
 .. autoclass:: flask_discord_interactions.SlashCommand
     :members:
 
-.. autoclass:: flask_discord_interactions.SlashCommandSubgroup
-    :members:
-    :show-inheritance:
+Slash Command Groups
+--------------------
+
+The Discord API treats subcommands as options given to the main command.
+However, this library provides an alternative way of declaring commands as
+belonging to a :class:`.SlashCommandGroup` or a :class:`.SlashCommandSubgroup`.
+
+To create a :class:`.SlashCommandGroup`, use the
+:meth:`.DiscordInteractions.command_group` method:
+
+.. code-block:: python
+
+    comic = discord.command_group("comic")
+
+
+    @comic.command()
+    def xkcd(ctx, number: int):
+        return f"https://xkcd.com/{number}/"
+
+
+    @comic.command()
+    def homestuck(ctx, number: int):
+        return f"https://homestuck.com/story/{number}"
+
+You can then use the :meth:`.SlashCommandGroup.command` decorator to
+register subcommands.
+
+Full API
+^^^^^^^^
 
 .. autoclass:: flask_discord_interactions.SlashCommandGroup
     :members:
+    :inherited-members:
     :show-inheritance:
+
+
+Slash Command Subgroups
+-----------------------
+
+You can also create subgroups that sit "in between" a
+:class:`.SlashCommandGroup` and a :class:`.SlashCommand` using the
+:meth:`.SlashCommandGroup.subgroup` decorator.
+
+.. code-block:: python
+
+    base = discord.command_group("base", "Convert a number between bases")
+
+    base_to = base.subgroup("to", "Convert a number into a certain base")
+    base_from = base.subgroup("from", "Convert a number out of a certian base")
+
+
+    @base_to.command(name="bin")
+    def base_to_bin(ctx, number: int):
+        "Convert a number into binary"
+        return Response(bin(number), ephemeral=True)
+
+
+    @base_to.command(name="hex")
+    def base_to_hex(ctx, number: int):
+        "Convert a number into hexadecimal"
+        return Response(hex(number), ephemeral=True)
+
+
+    @base_from.command(name="bin")
+    def base_from_bin(ctx, number: str):
+        "Convert a number out of binary"
+        return Response(int(number, base=2), ephemeral=True)
+
+
+    @base_from.command(name="hex")
+    def base_from_hex(ctx, number: str):
+        "Convert a number out of hexadecimal"
+        return Response(int(number, base=16), ephemeral=True)
+
+Full API
+^^^^^^^^
+
+.. autoclass:: flask_discord_interactions.SlashCommandSubgroup
+    :members:
+    :inherited-members:
+    :show-inheritance:
+

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -51,7 +51,7 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-# html_theme = 'alabaster'
+html_theme = 'alabaster'
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,8 +29,13 @@ author = 'Wesley Chalmers'
 # ones.
 extensions = [
     "sphinx.ext.autodoc",
-    "sphinx.ext.napoleon"
+    "sphinx.ext.napoleon",
+    "sphinx.ext.intersphinx"
 ]
+
+intersphinx_mapping = {
+  'py': ('https://docs.python.org/3', None),
+}
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/context.rst
+++ b/docs/context.rst
@@ -1,35 +1,47 @@
+.. _context-page:
+
 Context
 =======
-
-Interaction Context
--------------------
 
 This class provides context information about the incoming interaction as a
 whole.
 
+You normally would receive this as a ``ctx`` parameter to your
+:class:`.SlashCommand` function, similar to in Discord.py.
+
+.. code-block:: python
+
+    @discord.command()
+    def my_user_id(ctx):
+        "Show your user ID"
+        return f"Your ID is {ctx.author.id}"
+
+This object is always passed in as the first positional argument to your
+command function. You shouldn't ever need to create one yourself.
+
+You can also use this object to send followup messages, edit messages, and
+delete messages:
+
+.. code-block:: python
+
+    @discord.command()
+    def delay(ctx, duration: int):
+        def do_delay():
+            time.sleep(duration)
+
+            ctx.edit("Hi! I waited for you :)")
+
+        thread = threading.Thread(target=do_delay)
+        thread.start()
+
+        return Response(deferred=True)
+
+Pass in either a :class:`.Response` object or a string (which will be converted
+into a :class:`.Response` object. See :ref:`response-page` for more details.
+
+Full API
+--------
+
 .. autoclass:: flask_discord_interactions.Context
     :members:
 
-Interaction Objects
--------------------
-
-These classes represent options passed to a Slash Command.
-
-.. autoclass:: flask_discord_interactions.CommandOptionType
-    :members:
-
-.. autoclass:: flask_discord_interactions.Channel
-    :members:
-
-.. autoclass:: flask_discord_interactions.ChannelType
-    :members:
-
-.. autoclass:: flask_discord_interactions.User
-    :members:
-
-.. autoclass:: flask_discord_interactions.Member
-    :members:
-    :show-inheritance:
-
-.. autoclass:: flask_discord_interactions.Role
-    :members:

--- a/docs/discord.rst
+++ b/docs/discord.rst
@@ -1,8 +1,13 @@
 Discord
 =======
 
-The :class:`.DiscordInteractions` class manages a collection of
-:class:`.SlashCommand` s for you.
+The :class:`.DiscordInteractions` and :class:`.DiscordInteractionsBlueprint`
+classes manage a collection of :class:`.SlashCommand` s for you.
+
+DiscordInteractions
+-------------------
+
+
 
 Generally, the first thing you want to do in your application is create your
 Flask app and then your :class:`.DiscordInteractions` object:
@@ -142,6 +147,9 @@ As your app grows, Blueprints are a great way to keep things organized.
 Note that you can also use the
 :meth:`.DiscordInteractionsBlueprint.command_group` method to create a
 command group, just like with the :class:`.DiscordInteractions` object.
+
+Full API
+^^^^^^^^
 
 .. autoclass:: flask_discord_interactions.DiscordInteractionsBlueprint
     :members:

--- a/docs/discord.rst
+++ b/docs/discord.rst
@@ -1,9 +1,147 @@
 Discord
 =======
 
-.. autoclass:: flask_discord_interactions.DiscordInteractionsBlueprint
-    :members:
+The :class:`.DiscordInteractions` class manages a collection of
+:class:`.SlashCommand` s for you.
+
+Generally, the first thing you want to do in your application is create your
+Flask app and then your :class:`.DiscordInteractions` object:
+
+.. code-block:: python
+
+    from flask import Flask
+    from flask_discord_interactions import DiscordInteractions
+
+    app = Flask(__name__)
+    discord = DiscordInteractions(app)
+
+Then, you need to provide your authentication information for Discord. You
+must provide:
+
+* Client ID of your application
+* Public Key assigned to your application (used to authenticate incoming webhooks from Discord)
+* Client Secret of your application (used to request an OAuth2 token and register slash commands)
+
+For a more tutorial-style explaination of this, see :ref:`tutorial-page`.
+
+.. code-block:: python
+
+    import os
+
+    app.config["DISCORD_CLIENT_ID"] = os.environ["DISCORD_CLIENT_ID"]
+    app.config["DISCORD_PUBLIC_KEY"] = os.environ["DISCORD_PUBLIC_KEY"]
+    app.config["DISCORD_CLIENT_SECRET"] = os.environ["DISCORD_CLIENT_SECRET"]
+
+Next, define your commands using the :meth:`.DiscordInteractions.command`
+decorator and :meth:`.DiscordInteractions.command_group` function. For more
+information about defining commands, see :ref:`command-page`.
+
+.. code-block:: python
+
+    @discord.command()
+    def ping(ctx):
+        "Respond with a friendly 'pong'!"
+        return "Pong!"
+
+Next, set the URL path that your app will listen for Discord Interactions on.
+This is the part that you will enter into the Discord Developer Portal.
+
+You could use the root URL ``"/"``, but you might want to pick a different path
+like ``"/interactions"``. That way, you can serve your bot's website at ``"/"``
+from the same Flask app.
+
+.. code-block:: python
+
+    discord.set_route("/interactions")
+
+Finally, you need to register the slash commands with Discord.
+:meth:`.DiscordInteractions.update_slash_commands` will automatically get
+the list of currently registered slash commands, delete any that are no longer
+defined, update any that have changed, and register any newly-defined ones.
+*Note that this may take a while due to Discord rate-limiting, especially
+if you are running your bot for the first time.*
+
+You can optionally pass in a ``guild_id`` parameter. This will register
+the commands in a specific guild instead of registering them globally.
+This is the recommended approach for testing, since registering new global
+commands can take up to 1 hour.
+
+.. code-block:: python
+
+    discord.update_slash_commands(guild_id=os.environ["TESTING_GUILD"])
+
+Now, like any other Flask app, all that's left to do is:
+
+.. code-block:: python
+
+    if __name__ == '__main__':
+        app.run()
+
+Running this code should serve your app locally. For production,
+your app can be deployed like any other Flask app (using ``gunicorn``, etc).
+
+Full API
+^^^^^^^^
 
 .. autoclass:: flask_discord_interactions.DiscordInteractions
     :members:
     :show-inheritance:
+    :inherited-members:
+
+Blueprints
+----------
+
+Similarly to Flask, you can use Blueprints to split your bot's commands
+across multiple files. You can't use Flask Blueprints for this, because all
+interactions from Discord are sent to the same URL. However, this library
+provides a :class:`.DiscordInteractionsBlueprint` class which you can use
+similarly to a Flask blueprint.
+
+Here's an example of a simple echo bot split into two files.
+
+.. code-block:: python
+    :caption: echo.py
+
+    from flask_discord_interactions import DiscordInteractionsBlueprint
+
+    bp = DiscordInteractionsBlueprint()
+
+    @bp.command()
+    def echo(ctx, text: str):
+        "Repeat a string"
+        return f"*Echooo!!!* {text}"
+
+
+.. code-block:: python
+    :caption: main.py
+
+    import os
+
+    from flask import Flask
+    from flask_discord_interactions import DiscordInteractions
+
+    from echo import bp as echo_bp
+
+    app = Flask(__name__)
+    discord = DiscordInteractions(app)
+
+    app.config["DISCORD_CLIENT_ID"] = os.environ["DISCORD_CLIENT_ID"]
+    app.config["DISCORD_PUBLIC_KEY"] = os.environ["DISCORD_PUBLIC_KEY"]
+    app.config["DISCORD_CLIENT_SECRET"] = os.environ["DISCORD_CLIENT_SECRET"]
+
+    discord.register_blueprint(echo_bp)
+
+
+    discord.set_route("/interactions")
+    discord.update_slash_commands(guild_id=os.environ["TESTING_GUILD"])
+
+    if __name__ == '__main__':
+        app.run()
+
+As your app grows, Blueprints are a great way to keep things organized.
+Note that you can also use the
+:meth:`.DiscordInteractionsBlueprint.command_group` method to create a
+command group, just like with the :class:`.DiscordInteractions` object.
+
+.. autoclass:: flask_discord_interactions.DiscordInteractionsBlueprint
+    :members:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -33,7 +33,7 @@ Documentation
 -------------
 
 .. toctree::
-    :maxdepth: 1
+    :maxdepth: 2
 
     api.rst
     tutorial.rst

--- a/docs/options.rst
+++ b/docs/options.rst
@@ -1,0 +1,137 @@
+.. _options-page:
+
+Options
+=======
+
+Discord allows Slash Commands to receive a variety of different option types.
+Each option has a name, description, and type.
+
+To specify options with Flask-Discord-Interactions, you can use type
+annotations. This syntax should feel familiar to users of Discord.py.
+
+.. code-block:: python
+
+    @discord.command(annotations={"message": "The message to repeat"})
+    def repeat(ctx, message: str = "Hello!"):
+        "Repeat the message (and escape mentions)"
+        return Response(
+            f"{ctx.author.display_name} says {message}!",
+            allowed_mentions={"parse": []},
+        )
+
+The ``annotations`` parameter is used to provide a description for each option
+(they default to "no description"). See :meth:`.DiscordInteractions.command`
+for more information about the decorator.
+
+Primitives
+^^^^^^^^^^
+
+You can use ``str``, ``int``, or ``bool`` for string, integer, and boolean
+options.
+
+.. code-block:: python
+
+    @discord.command()
+    def add_one(ctx, number: int):
+        return Response(str(number + 1), ephemeral=True)
+
+
+    @discord.command()
+    def and_gate(ctx, a: bool, b: bool):
+        return f"{a} AND {b} is {a and b}"
+
+Discord Models
+^^^^^^^^^^^^^^
+
+For User, Channel, and Role options, you can receive an object with context
+information about the option:
+
+.. code-block:: python
+
+    @discord.command()
+    def has_role(ctx, user: Member, role: Role):
+        if role.id in user.roles:
+            return f"Yes, user {user.display_name} has role {role.name}."
+        else:
+            return f"No, user {user.display_name} does not have role {role.name}."
+
+Choices
+^^^^^^^
+
+To specify a list of choices the user can choose from, you can use Python's
+:py:class:`enum.Enum` class.
+
+.. code-block:: python
+
+    class Animal(enum.Enum):
+        Dog = "dog"
+        Cat = "cat"
+
+
+    @discord.command(annotations={"choice": "Your favorite animal"})
+    def favorite(ctx, choice: Animal):
+        "What is your favorite animal?"
+        return f"{ctx.author.display_name} chooses {choice}!"
+
+Note that you can use the same enum in multiple commands if they share the same
+choices:
+
+.. code-block:: python
+
+    @discord.command(annotations={"choice": "The animal you hate the most"})
+    def hate(ctx, choice: Animal):
+        "What is the animal you hate the most?"
+        return f"{ctx.author.display_name} hates {choice}s."
+
+You can also use an :py:class:`enum.IntEnum` to receive the value as an integer
+instead of a string:
+
+.. code-block:: python
+
+    class BigNumber(enum.IntEnum):
+        thousand = 1_000
+        million  = 1_000_000
+        billion  = 1_000_000_000
+        trillion = 1_000_000_000_000
+
+
+    @discord.command(annotations={"number": "A big number"})
+    def big_number(ctx, number: BigNumber):
+        "Print out a large number"
+        return f"One more than the number is {number+1}."
+
+Full API
+^^^^^^^^
+
+.. autoclass:: flask_discord_interactions.CommandOptionType
+    :members:
+    :undoc-members:
+    :member-order: bysource
+
+|
+
+.. autoclass:: flask_discord_interactions.Channel
+    :members:
+
+|
+
+.. autoclass:: flask_discord_interactions.ChannelType
+    :members:
+    :undoc-members:
+    :member-order: bysource
+
+|
+
+.. autoclass:: flask_discord_interactions.User
+    :members:
+
+|
+
+.. autoclass:: flask_discord_interactions.Member
+    :members:
+    :show-inheritance:
+
+|
+
+.. autoclass:: flask_discord_interactions.Role
+    :members:

--- a/docs/options.rst
+++ b/docs/options.rst
@@ -24,7 +24,7 @@ The ``annotations`` parameter is used to provide a description for each option
 for more information about the decorator.
 
 Primitives
-^^^^^^^^^^
+----------
 
 You can use ``str``, ``int``, or ``bool`` for string, integer, and boolean
 options.
@@ -41,7 +41,7 @@ options.
         return f"{a} AND {b} is {a and b}"
 
 Discord Models
-^^^^^^^^^^^^^^
+--------------
 
 For User, Channel, and Role options, you can receive an object with context
 information about the option:
@@ -56,7 +56,7 @@ information about the option:
             return f"No, user {user.display_name} does not have role {role.name}."
 
 Choices
-^^^^^^^
+-------
 
 To specify a list of choices the user can choose from, you can use Python's
 :py:class:`enum.Enum` class.
@@ -101,7 +101,7 @@ instead of a string:
         return f"One more than the number is {number+1}."
 
 Full API
-^^^^^^^^
+--------
 
 .. autoclass:: flask_discord_interactions.CommandOptionType
     :members:

--- a/docs/response.rst
+++ b/docs/response.rst
@@ -1,8 +1,92 @@
+.. _response-page:
+
 Response
 ========
 
-.. autoclass:: flask_discord_interactions.ResponseType
-    :members:
+Response objects are used whenever your bot responds to an Interaction or sends
+or edits a followup message. They can contain content, embeds, files, and
+other parameters depending on the situation.
+
+In most cases, you can return a string and it will be converted into a
+:class:`.Response` object:
+
+.. code-block:: python
+
+    @discord.command()
+    def just_content(ctx):
+        "Just normal string content"
+        return "Just return a string to send it as a message"
+
+
+    @discord.command()
+    def markdown(ctx):
+        "Fancy markdown tricks"
+        return "All *the* **typical** ~~discord~~ _markdown_ `works` ***too.***"
+
+Alternatively, you can create a Response object yourself:
+
+.. code-block:: python
+
+    @discord.command()
+    def response_object(ctx):
+        "Just normal string content"
+        return Response("Return a Response object with the content")
+
+You can also pass more options to the Response object, such as making the
+response ephemeral:
+
+.. code-block:: python
+
+    @discord.command()
+    def ephemeral(ctx):
+        "Ephemeral Message"
+
+        return Response(
+            "Ephemeral messages are only sent to the user who ran the command, "
+            "and they go away after a short while.\n\n"
+            "Note that they cannot include embeds or files, "
+            "but Markdown is *perfectly fine.*",
+            ephemeral=True
+        )
+
+Note that this only works with the initial response, not for followup messages.
+
+For followup messages (*not* the initial response), you can also attach files:
+
+.. code-block:: python
+
+    @discord.command()
+    def followup(ctx):
+        def do_followup():
+            print("Followup task started")
+            time.sleep(5)
+
+            print("Sending a file")
+            ctx.send(Response(
+                content="Sending a file",
+                file=("README.md", open("README.md", "r"), "text/markdown")))
+
+        thread = threading.Thread(target=do_followup)
+        thread.start()
+
+        return "Sending an original message"
+
+The ``allowed_mentions`` parameter can be used to restrict which users and
+roles the message should mention. It is a good idea to use this whenever your
+bot is echoing user input. You can read more about this parameter on the
+`Discord API docs <https://discord.com/developers/docs/resources/channel#allowed-mentions-object>`_.
+
+Full API
+^^^^^^^^
 
 .. autoclass:: flask_discord_interactions.Response
     :members:
+
+|
+
+.. autoclass:: flask_discord_interactions.ResponseType
+    :members:
+    :undoc-members:
+    :member-order: bysource
+
+

--- a/docs/response.rst
+++ b/docs/response.rst
@@ -77,7 +77,7 @@ bot is echoing user input. You can read more about this parameter on the
 `Discord API docs <https://discord.com/developers/docs/resources/channel#allowed-mentions-object>`_.
 
 Full API
-^^^^^^^^
+--------
 
 .. autoclass:: flask_discord_interactions.Response
     :members:

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -1,3 +1,5 @@
+.. _tutorial-page:
+
 Bot Setup Tutorial
 ==================
 
@@ -41,9 +43,9 @@ The example also uses the environment variable `TESTING_GUILD` to store the ID o
 Run the program
 ---------------
 
-You should be able to run an example program without any errors now. It should register slash commands in your server. However, these slash commands will not work yet.
+You should be able to run a program without any errors now. It should register slash commands in your server. However, these slash commands will not work yet.
 
-Here's a quick "hello world" program, or you can look in the project examples directory.
+Here's a quick "hello world" program:
 
 .. code-block:: python
 

--- a/flask_discord_interactions/context.py
+++ b/flask_discord_interactions/context.py
@@ -193,8 +193,7 @@ class Role:
 
 class Context:
     """
-    Represents the context in which a :class:`SlashCommand` is invoked,
-    including the invoking user ID, channel ID, guild ID, options, etc.
+    Represents the context in which a :class:`SlashCommand` is invoked.
 
     Attributes
     ----------


### PR DESCRIPTION
This PR adds additional information and examples to each page of the documentation. This will allow users to get the information they need without having to search both the documentation and the examples directory.