### PR TITLE
Response and Embed Dataclasses

### DIFF
--- a/docs/response.rst
+++ b/docs/response.rst
@@ -1,7 +1,10 @@
 .. _response-page:
 
-Response
-========
+Responses
+=========
+
+Response objects
+----------------
 
 Response objects are used whenever your bot responds to an Interaction or sends
 or edits a followup message. They can contain content, embeds, files, and
@@ -77,9 +80,9 @@ bot is echoing user input. You can read more about this parameter on the
 `Discord API docs <https://discord.com/developers/docs/resources/channel#allowed-mentions-object>`_.
 
 Full API
---------
+^^^^^^^^
 
-.. autoclass:: flask_discord_interactions.Response
+.. autoclass:: flask_discord_interactions.Response(**kwargs)
     :members:
 
 |
@@ -89,4 +92,73 @@ Full API
     :undoc-members:
     :member-order: bysource
 
+Embeds
+------
 
+Embed objects let you represent Embeds which you can return as part of
+responses.
+
+.. code-block:: python
+
+    from flask_discord_interactions import Embed, embed
+
+    @discord.command()
+    def my_embed(ctx):
+        "Embeds!"
+
+        return Response(embed=Embed(
+            title="Embeds!",
+            description="Embeds can be specified as Embed objects.",
+            fields=[
+                embed.Field(
+                    name="Can they use markdown?",
+                    value="**Yes!** [link](https://google.com/)"
+                ),
+                embed.Field(
+                    name="Where do I learn about how to format this object?",
+                    value=("[Try this visualizer!]"
+                        "(https://leovoel.github.io/embed-visualizer/)")
+                )
+            ]
+        ))
+
+The :class:`.Embed` class represents a single Embed. You can also use
+:class:`.embed.Field`, :class:`.embed.Author`, :class:`.embed.Footer`, or
+:class:`.embed.Provider` for those fields. :class:`.embed.Media` can be used
+for images, videos, and thumbnails.
+
+Full API
+^^^^^^^^
+
+.. autoclass:: flask_discord_interactions.Embed(**kwargs)
+    :members:
+
+|
+
+.. autoclass:: flask_discord_interactions.embed.Field
+    :members:
+    :undoc-members:
+
+|
+
+.. autoclass:: flask_discord_interactions.embed.Author
+    :members:
+    :undoc-members:
+
+|
+
+.. autoclass:: flask_discord_interactions.embed.Footer
+    :members:
+    :undoc-members:
+
+|
+
+.. autoclass:: flask_discord_interactions.embed.Provider
+    :members:
+    :undoc-members:
+
+|
+
+.. autoclass:: flask_discord_interactions.embed.Media
+    :members:
+    :undoc-members:

--- a/examples/response.py
+++ b/examples/response.py
@@ -6,7 +6,7 @@ from flask import Flask
 sys.path.insert(1, ".")
 
 from flask_discord_interactions import (DiscordInteractions,  # noqa: E402
-                                        Response)
+                                        Response, Embed, embed)
 
 
 app = Flask(__name__)
@@ -31,13 +31,34 @@ def markdown(ctx):
     return "All *the* **typical** ~~discord~~ _markdown_ `works` ***too.***"
 
 
-@discord.command()
-def embed(ctx):
+@discord.command(name="embed")
+def embed_(ctx):
     "Embeds!"
+
+    return Response(embed=Embed(
+        title="Embeds!",
+        description="Embeds can be specified as Embed objects.",
+        fields=[
+            embed.Field(
+                name="Can they use markdown?",
+                value="**Yes!** [link](https://google.com/)"
+            ),
+            embed.Field(
+                name="Where do I learn about how to format this object?",
+                value=("[Try this visualizer!]"
+                       "(https://leovoel.github.io/embed-visualizer/)")
+            )
+        ]
+    ))
+
+
+@discord.command()
+def dict_embed(ctx):
+    "Embeds as dict objects!"
 
     return Response(embed={
         "title": "Embeds!",
-        "description": "Embeds must be specified as JSON objects.",
+        "description": "Embeds can also be specified as JSON objects.",
         "fields": [
             {
                 "name": "Can they use markdown?",

--- a/flask_discord_interactions/__init__.py
+++ b/flask_discord_interactions/__init__.py
@@ -20,6 +20,8 @@ from flask_discord_interactions.discord import (
 )
 
 from flask_discord_interactions.response import Response, ResponseType
+import flask_discord_interactions.embed as embed
+from flask_discord_interactions.embed import Embed
 from flask_discord_interactions.client import Client
 
 
@@ -29,6 +31,8 @@ InteractionContext = Context
 
 
 __all__ = [
+    "embed",
+
     "SlashCommand",
     "SlashCommandSubgroup",
     "SlashCommandGroup",
@@ -43,6 +47,7 @@ __all__ = [
     "DiscordInteractionsBlueprint",
     "Response",
     "ResponseType",
+    "Embed",
     "Client",
 
     "InteractionResponse",

--- a/flask_discord_interactions/command.py
+++ b/flask_discord_interactions/command.py
@@ -4,6 +4,7 @@ import itertools
 
 from flask_discord_interactions.context import (Context, CommandOptionType,
                                                 User, Member, Channel, Role)
+from flask_discord_interactions.response import Response
 
 
 class SlashCommand:
@@ -128,12 +129,20 @@ class SlashCommand:
             The Flask app used to receive this interaction.
         data
             The incoming interaction data.
+
+        Returns
+        -------
+        Response
+            The response by the command, converted to a Response object.
         """
 
         context = Context.from_data(discord, app, data)
         args, kwargs = context.create_args(
             data["data"], resolved=data["data"].get("resolved"))
-        return self.run(context, *args, **kwargs)
+
+        result = self.run(context, *args, **kwargs)
+
+        return Response.from_return_value(result)
 
     def run(self, context, *args, **kwargs):
         """

--- a/flask_discord_interactions/discord.py
+++ b/flask_discord_interactions/discord.py
@@ -376,4 +376,4 @@ class DiscordInteractions(DiscordInteractionsBlueprint):
                     "type": ResponseType.PONG
                 })
 
-            return jsonify(self.run_command(request.json))
+            return jsonify(self.run_command(request.json).dump())

--- a/flask_discord_interactions/discord.py
+++ b/flask_discord_interactions/discord.py
@@ -376,8 +376,4 @@ class DiscordInteractions(DiscordInteractionsBlueprint):
                     "type": ResponseType.PONG
                 })
 
-            result = self.run_command(request.json)
-
-            response = Response.from_return_value(result)
-
-            return jsonify(response.dump())
+            return jsonify(self.run_command(request.json))

--- a/flask_discord_interactions/embed.py
+++ b/flask_discord_interactions/embed.py
@@ -1,0 +1,55 @@
+from dataclasses import dataclass
+from typing import List
+
+@dataclass
+class Footer:
+    "Represents the footer of an Embed."
+    text: str
+    icon_url: str = None
+    proxy_icon_url: str = None
+
+@dataclass
+class Field:
+    "Represents a field on an Embed."
+    name: str
+    value: str
+    inline: bool = False
+
+@dataclass
+class Media:
+    "Represents a thumbnail, image, or video on an Embed."
+    url: str
+    proxy_url: str
+    height: int
+
+@dataclass
+class Provider:
+    "Represents a provider of an Embed."
+    name: str = None
+    url: str = None
+
+@dataclass
+class Author:
+    "Represents an author of an embed."
+    name: str = None
+    url: str = None
+    icon_url: str = None
+    proxy_icon_url: str = None
+
+@dataclass
+class Embed:
+    """
+    Represents an Embed to be sent as part of a Response.
+    """
+    title: str = None
+    description: str = None
+    url: str = None
+    timestamp: str = None
+    color: int = None
+    footer: Footer = None
+    image: Media = None
+    thumbnail: Media = None
+    video: Media = None
+    provider: Provider = None
+    author: Author = None
+    fields: List[Field] = None

--- a/flask_discord_interactions/embed.py
+++ b/flask_discord_interactions/embed.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, asdict
 from typing import List
 
 @dataclass
@@ -18,9 +18,10 @@ class Field:
 @dataclass
 class Media:
     "Represents a thumbnail, image, or video on an Embed."
-    url: str
-    proxy_url: str
-    height: int
+    url: str = None
+    proxy_url: str = None
+    height: int = None
+    width: int = None
 
 @dataclass
 class Provider:
@@ -53,3 +54,14 @@ class Embed:
     provider: Provider = None
     author: Author = None
     fields: List[Field] = None
+
+    def dump(self):
+        "Returns this Embed as a dictionary, removing fields which are None."
+        def filter_none(d):
+            if isinstance(d, dict):
+                return {k: filter_none(v)
+                        for k, v in d.items() if v is not None}
+            else:
+                return d
+
+        return filter_none(asdict(self))

--- a/flask_discord_interactions/embed.py
+++ b/flask_discord_interactions/embed.py
@@ -41,6 +41,26 @@ class Author:
 class Embed:
     """
     Represents an Embed to be sent as part of a Response.
+
+    Attributes
+    ----------
+    title
+        The title of the embed.
+    description
+        The description in the embed.
+    url
+        The URL that the embed title links to.
+    timestamp
+        An ISO8601 timestamp included in the embed.
+    color
+        An integer representing the color of the sidebar of the embed.
+    footer
+    image
+    thumbnail
+    video
+    provider
+    author
+    fields
     """
     title: str = None
     description: str = None

--- a/flask_discord_interactions/response.py
+++ b/flask_discord_interactions/response.py
@@ -78,6 +78,11 @@ class Response:
             raise ValueError(
                 "Ephemeral responses cannot include embeds or files.")
 
+        if self.embeds is not None:
+            for i, embed in enumerate(self.embeds):
+                if not dataclasses.is_dataclass(embed):
+                    self.embeds[i] = Embed(**embed)
+
     @property
     def response_type(self):
         "The Discord response type of the Interaction response."
@@ -94,19 +99,12 @@ class Response:
         """
         return 64 if self.ephemeral else 0
 
-    @property
-    def embeds_as_dict(self):
+    def dump_embeds(self):
         "Returns the embeds of this Response as a list of dicts."
         if self.embeds is None:
             return None
 
-        embeds = []
-        for embed in self.embeds:
-            if dataclasses.is_dataclass(embed):
-                embeds.append(dataclasses.asdict(embed))
-            else:
-                embeds.append(embed)
-        return embeds
+        return [dataclasses.asdict(embed) for embed in self.embeds]
 
     @classmethod
     def from_return_value(cls, result):
@@ -143,7 +141,7 @@ class Response:
             "data": {
                 "content": self.content,
                 "tts": self.tts,
-                "embeds": self.embeds_as_dict,
+                "embeds": self.dump_embeds(),
                 "allowed_mentions": self.allowed_mentions,
                 "flags": self.flags
             }
@@ -161,7 +159,7 @@ class Response:
         return {
             "content": self.content,
             "tts": self.tts,
-            "embeds": self.embeds_as_dict,
+            "embeds": self.dump_embeds(),
             "allowed_mentions": self.allowed_mentions
         }
 

--- a/flask_discord_interactions/response.py
+++ b/flask_discord_interactions/response.py
@@ -101,10 +101,7 @@ class Response:
 
     def dump_embeds(self):
         "Returns the embeds of this Response as a list of dicts."
-        if self.embeds is None:
-            return None
-
-        return [dataclasses.asdict(embed) for embed in self.embeds]
+        return [embed.dump() for embed in self.embeds] if self.embeds else None
 
     @classmethod
     def from_return_value(cls, result):

--- a/flask_discord_interactions/response.py
+++ b/flask_discord_interactions/response.py
@@ -97,6 +97,9 @@ class Response:
     @property
     def embeds_as_dict(self):
         "Returns the embeds of this Response as a list of dicts."
+        if self.embeds is None:
+            return None
+
         embeds = []
         for embed in self.embeds:
             if dataclasses.is_dataclass(embed):

--- a/flask_discord_interactions/response.py
+++ b/flask_discord_interactions/response.py
@@ -1,6 +1,9 @@
 import json
 import dataclasses
-from typing import List
+from typing import List, Union
+
+
+from flask_discord_interactions.embed import Embed
 
 
 class ResponseType:
@@ -45,8 +48,8 @@ class Response:
     """
     content: str = None
     tts: bool = False
-    embed: dict = None
-    embeds: List[dict] = None
+    embed: Union[Embed, dict] = None
+    embeds: List[Union[Embed, dict]] = None
     allowed_mentions: dict = dataclasses.field(
         default_factory=lambda: {"parse": ["roles", "users", "everyone"]})
     deferred: bool = False
@@ -91,6 +94,17 @@ class Response:
         """
         return 64 if self.ephemeral else 0
 
+    @property
+    def embeds_as_dict(self):
+        "Returns the embeds of this Response as a list of dicts."
+        embeds = []
+        for embed in self.embeds:
+            if dataclasses.is_dataclass(embed):
+                embeds.append(dataclasses.asdict(embed))
+            else:
+                embeds.append(embed)
+        return embeds
+
     @classmethod
     def from_return_value(cls, result):
         """
@@ -126,7 +140,7 @@ class Response:
             "data": {
                 "content": self.content,
                 "tts": self.tts,
-                "embeds": self.embeds,
+                "embeds": self.embeds_as_dict,
                 "allowed_mentions": self.allowed_mentions,
                 "flags": self.flags
             }
@@ -144,7 +158,7 @@ class Response:
         return {
             "content": self.content,
             "tts": self.tts,
-            "embeds": self.embeds,
+            "embeds": self.embeds_as_dict,
             "allowed_mentions": self.allowed_mentions
         }
 

--- a/flask_discord_interactions/response.py
+++ b/flask_discord_interactions/response.py
@@ -91,28 +91,6 @@ class Response:
         """
         return 64 if self.ephemeral else 0
 
-    @property
-    def allowed_initial(self):
-        """
-        Returns if this Response is valid to send as an initial Interaction
-        response (i.e., if it does not contain files).
-        """
-        if self.files:
-            return False
-        return True
-
-    @property
-    def allowed_followup(self):
-        """
-        Returns if this Response is valid to send as a followup Interaction
-        response/webhook (i.e., if it is not set as ephemeral or deferred).
-        """
-        if self.ephemeral:
-            return False
-        if self.deferred:
-            return False
-        return True
-
     @classmethod
     def from_return_value(cls, result):
         """
@@ -139,6 +117,10 @@ class Response:
         incoming webhook.
         """
 
+        if self.files:
+            raise ValueError(
+                "files are not allowed in an initial Interaction response")
+
         return {
             "type": self.response_type,
             "data": {
@@ -154,6 +136,10 @@ class Response:
         """
         Return this ``Response`` as a dict to be sent to an outgoing webhook.
         """
+
+        if self.ephemeral or self.deferred:
+            raise ValueError(
+                "ephemeral and deferred are not valid in followup responses")
 
         return {
             "content": self.content,

--- a/flask_discord_interactions/tests/test_response.py
+++ b/flask_discord_interactions/tests/test_response.py
@@ -1,4 +1,6 @@
-from flask_discord_interactions import Response
+import pytest
+
+from flask_discord_interactions import Response, Embed, embed
 
 
 def test_content(discord, client):
@@ -9,22 +11,72 @@ def test_content(discord, client):
     assert client.run("content").content == "quality content"
 
 
-def test_embed(discord, client):
-    embed = {
+def test_dict_embed(discord, client):
+    my_embed = {
         "title": "My Cool Embed"
     }
 
     @discord.command()
     def embeddy(ctx):
-        return Response(embed=embed)
+        return Response(embed=my_embed)
 
-    assert client.run("embeddy").embeds == [embed]
+    assert client.run("embeddy").dump_embeds() == [my_embed]
 
     @discord.command()
     def multiple(ctx):
-        return Response(embeds=[embed, embed])
+        return Response(embeds=[my_embed, my_embed])
 
-    assert client.run("multiple").embeds == [embed, embed]
+    assert client.run("multiple").dump_embeds() == [my_embed, my_embed]
+
+
+def test_class_embed(discord, client):
+    my_embed = Embed(
+        title="My Cool Embed",
+        image=embed.Media(url="https://google.com")
+    )
+
+    output = {
+        "title": "My Cool Embed",
+        "image": {
+            "url": "https://google.com"
+        }
+    }
+
+    @discord.command()
+    def embeddy(ctx):
+        return Response(embed=my_embed)
+
+    assert client.run("embeddy").dump_embeds() == [output]
+
+    @discord.command()
+    def multiple(ctx):
+        return Response(embeds=[my_embed, my_embed])
+
+    assert client.run("multiple").dump_embeds() == [output, output]
+
+
+def test_improper_immediate(discord, client):
+    @discord.command()
+    def improper_immediate(ctx):
+        return Response(
+            file=("README.md", open("README.md", "r"), "text/markdown")
+        )
+
+    result = client.run("improper_immediate")
+
+    with pytest.raises(ValueError):
+        result.dump()
+
+
+def test_improper_followup(discord, client):
+    @discord.command()
+    def improper_followup(ctx):
+        return Response("hi", ephemeral=True)
+
+    result = client.run("improper_followup")
+
+    with pytest.raises(ValueError):
+        result.dump_followup()
 
 
 def test_ephemeral(discord, client):

--- a/flask_discord_interactions/tests/test_response.py
+++ b/flask_discord_interactions/tests/test_response.py
@@ -1,6 +1,8 @@
+import json
+
 import pytest
 
-from flask_discord_interactions import Response, Embed, embed
+from flask_discord_interactions import Response, ResponseType, Embed, embed
 
 
 def test_content(discord, client):
@@ -56,16 +58,20 @@ def test_class_embed(discord, client):
 
 
 def test_improper_immediate(discord, client):
+    fp = open("README.md", "r")
+
     @discord.command()
     def improper_immediate(ctx):
         return Response(
-            file=("README.md", open("README.md", "r"), "text/markdown")
+            file=("README.md", fp, "text/markdown")
         )
 
     result = client.run("improper_immediate")
 
     with pytest.raises(ValueError):
         result.dump()
+
+    fp.close()
 
 
 def test_improper_followup(discord, client):
@@ -86,3 +92,72 @@ def test_ephemeral(discord, client):
 
     assert client.run("ephemeral").content == "hi"
     assert client.run("ephemeral").flags == 64
+
+
+def test_dump_immediate(discord, client):
+    @discord.command()
+    def use_response(ctx):
+        return Response("hi", tts=True, embed=Embed(title="hello!"))
+
+    expected = {
+        "type": ResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
+        "data": {
+            "content": "hi",
+            "embeds": [{
+                "title": "hello!"
+            }],
+            "flags": 0,
+            "tts": True,
+            "allowed_mentions": {"parse": ["roles", "users", "everyone"]}
+        }
+    }
+
+    assert client.run("use_response").dump() == expected
+
+
+def test_dump_followup():
+    resp = Response(
+        content="Followup",
+        embed=Embed(title="hello!"),
+    )
+
+    expected = {
+        "content": "Followup",
+        "embeds": [{
+            "title": "hello!"
+        }],
+        "tts": False,
+        "allowed_mentions": {"parse": ["roles", "users", "everyone"]}
+    }
+
+    assert resp.dump_followup() == expected
+
+
+def test_dump_multipart():
+    fp = open("README.md", "r")
+    resp = Response(
+        content="Followup",
+        embed=Embed(title="hello!"),
+        file=("README.md", fp, "text/markdown")
+    )
+
+    expected = {
+        "data": {
+            "payload_json": json.dumps({
+                "content": "Followup",
+                "tts": False,
+                "embeds": [{
+                    "title": "hello!"
+                }],
+                "allowed_mentions": {"parse": ["roles", "users", "everyone"]}
+            })
+        },
+        "files": [
+            ("file", ("README.md", fp, "text/markdown"))
+        ]
+    }
+
+    try:
+        assert resp.dump_multipart() == expected
+    finally:
+        fp.close()


### PR DESCRIPTION
This PR changes `Response` to be a dataclass, and adds a new `Embed` dataclass to represent embeds. The user-facing API for the `Response` object should not change, except for `__repr__` and the other dataclass methods. The `Embed` dataclass makes it much easier to create embeds.

Old style (still supported):
```python
@discord.command()
def old_embed(ctx):
    return Response(embed={
        "title": "Embeds!",
        "description": "Embeds can also be specified as JSON objects.",
        "fields": [
            {
                "name": "Can they use markdown?",
                "value": "**Yes!** [link](https://google.com/)"
            },
            {
                "name": "Where do I learn about how to format this object?",
                "value": ("[Try this visualizer!]"
                          "(https://leovoel.github.io/embed-visualizer/)")
            }
        ]
    })
```
New style:
```python
@discord.command()
def new_embed(ctx):
    return Response(embed=Embed(
        title="Embeds!",
        description="Embeds can be specified as Embed objects.",
        fields=[
            embed.Field(
                name="Can they use markdown?",
                value="**Yes!** [link](https://google.com/)"
            ),
            embed.Field(
                name="Where do I learn about how to format this object?",
                value=("[Try this visualizer!]"
                       "(https://leovoel.github.io/embed-visualizer/)")
            )
        ]
    ))
```