### PR TITLE
Support Asyncio usage with Quart

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -11,3 +11,4 @@ API Reference
     options.rst
     response.rst
     client.rst
+    quart.rst

--- a/docs/quart.rst
+++ b/docs/quart.rst
@@ -1,0 +1,89 @@
+Using Asyncio with Quart
+========================
+
+`Quart <https://pgjones.gitlab.io/quart/>`_ is a Python web framework designed
+to have a similar API to Flask, but using :py:mod:`asyncio`.
+
+.. code-block:: python
+
+    from quart import Quart
+
+    app = Quart(__name__)
+
+    @app.route('/')
+    async def hello():
+        return 'hello'
+
+    app.run()
+
+Flask-Discord-Interactions supports using Quart. This can provide a more
+familiar development experience to those used to ``discord.py``'s
+async commands.
+
+Specifically, Quart supports
+`monkey patching
+<https://stackoverflow.com/questions/5626193/what-is-monkey-patching>`_
+to allow Flask extensions to run with Quart. The specifics of this are
+`in this tutorial
+<https://pgjones.gitlab.io/quart/tutorials/flask_ext_tutorial.html>`_.
+
+Flask-Discord-Interactions will work with this monkey patching. Additionally,
+this library has some extra logic to handle mixing async and non-async
+commands, and to allow awaiting when handling followup messages.
+
+.. code-block:: python
+
+    from quart import Quart
+
+    import quart.flask_patch
+    from flask_discord_interactions import DiscordInteractions
+
+    app = Quart(__name__)
+    discord = DiscordInteractions(app)
+
+    discord.update_slash_commands()
+
+    @discord.command()
+    async def ping(ctx):
+        "Respond with a friendly 'pong'!"
+        return "Pong!"
+
+    # Non-async functions still work
+    @discord.command()
+    def pong(ctx):
+        return "Ping!"
+
+A special :class:`.AsyncContext` class is exposed to asynchronous commands.
+This class makes :meth:`.AsyncContext.edit`, :meth:`.AsyncContext.send`, and
+:meth:`.AsyncContext.delete` awaitable.
+
+.. code-block:: python
+
+    @discord.command()
+    async def wait(ctx, seconds: int):
+
+        async def do_followup():
+            await asyncio.sleep(seconds)
+            await ctx.edit("Done!")
+            await ctx.close()
+
+        asyncio.create_task(do_followup())
+        return Response(deferred=True)
+
+    # Normal followups use the normal Context
+    @discord.command()
+    def wait_sync(ctx, seconds: int):
+
+        def do_followup():
+            time.sleep(seconds)
+            ctx.edit("Done!")
+
+        threading.Thread(target=do_followup).start()
+        return Response(deferred=True)
+
+Full API
+--------
+
+.. autoclass:: flask_discord_interactions.AsyncContext(**kwargs)
+    :show-inheritance:
+    :members:

--- a/examples/async_quart.py
+++ b/examples/async_quart.py
@@ -1,0 +1,47 @@
+import os
+import sys
+
+from quart import Quart
+
+# This is just here for the sake of examples testing
+# to make sure that the imports work
+# (you don't actually need it in your code)
+sys.path.insert(1, ".")
+
+import quart.flask_patch
+from flask_discord_interactions import DiscordInteractions  # noqa: E402
+
+
+app = Quart(__name__)
+discord = DiscordInteractions(app)
+
+app.config["DISCORD_CLIENT_ID"] = os.environ["DISCORD_CLIENT_ID"]
+app.config["DISCORD_PUBLIC_KEY"] = os.environ["DISCORD_PUBLIC_KEY"]
+app.config["DISCORD_CLIENT_SECRET"] = os.environ["DISCORD_CLIENT_SECRET"]
+
+
+discord.update_slash_commands()
+
+
+# You can now use async functions!
+@discord.command()
+async def ping(ctx):
+    "Respond with a friendly 'pong'!"
+    return "Pong!"
+
+
+# Non-async functions still work
+@discord.command()
+def pong(ctx):
+    return "Ping!"
+
+
+# Use set_route_async if you want to use Quart
+discord.set_route_async("/interactions")
+
+
+discord.update_slash_commands(guild_id=os.environ["TESTING_GUILD"])
+
+
+if __name__ == '__main__':
+    app.run()

--- a/examples/async_quart.py
+++ b/examples/async_quart.py
@@ -1,5 +1,8 @@
 import os
 import sys
+import time
+import asyncio
+import threading
 
 from quart import Quart
 
@@ -9,7 +12,8 @@ from quart import Quart
 sys.path.insert(1, ".")
 
 import quart.flask_patch
-from flask_discord_interactions import DiscordInteractions  # noqa: E402
+from flask_discord_interactions import (DiscordInteractions, # noqa: E402
+                                        Response)
 
 
 app = Quart(__name__)
@@ -34,6 +38,31 @@ async def ping(ctx):
 @discord.command()
 def pong(ctx):
     return "Ping!"
+
+
+# You can use followups with asyncio
+@discord.command()
+async def wait(ctx, seconds: int):
+
+    async def do_followup():
+        await asyncio.sleep(seconds)
+        await ctx.edit("Done!")
+        await ctx.close()
+
+    asyncio.create_task(do_followup())
+    return Response(deferred=True)
+
+
+# Normal followups work as well
+@discord.command()
+def wait_sync(ctx, seconds: int):
+
+    def do_followup():
+        time.sleep(seconds)
+        ctx.edit("Done!")
+
+    threading.Thread(target=do_followup).start()
+    return Response(deferred=True)
 
 
 # Use set_route_async if you want to use Quart

--- a/flask_discord_interactions/__init__.py
+++ b/flask_discord_interactions/__init__.py
@@ -6,6 +6,7 @@ from flask_discord_interactions.command import (
 
 from flask_discord_interactions.context import (
     Context,
+    AsyncContext,
     CommandOptionType,
     ChannelType,
     Member,
@@ -37,6 +38,7 @@ __all__ = [
     "SlashCommandSubgroup",
     "SlashCommandGroup",
     "Context",
+    "AsyncContext",
     "CommandOptionType",
     "ChannelType",
     "Member",

--- a/flask_discord_interactions/command.py
+++ b/flask_discord_interactions/command.py
@@ -3,7 +3,8 @@ import inspect
 import itertools
 
 from flask_discord_interactions.context import (Context, CommandOptionType,
-                                                User, Member, Channel, Role)
+                                                User, Member, Channel, Role,
+                                                AsyncContext)
 from flask_discord_interactions.response import Response
 
 
@@ -54,6 +55,8 @@ class SlashCommand:
             raise ValueError(
                 f"Error adding command {self.name}: "
                 "Command description must be between 1 and 100 characters.")
+
+        self.is_async = inspect.iscoroutinefunction(self.command)
 
         if self.options is None:
             sig = inspect.signature(self.command)
@@ -136,7 +139,10 @@ class SlashCommand:
             The response by the command, converted to a Response object.
         """
 
-        context = Context.from_data(discord, app, data)
+        if self.is_async:
+            context = AsyncContext.from_data(discord, app, data)
+        else:
+            context = Context.from_data(discord, app, data)
         args, kwargs = context.create_args(
             data["data"], resolved=data["data"].get("resolved"))
 

--- a/flask_discord_interactions/context.py
+++ b/flask_discord_interactions/context.py
@@ -428,6 +428,13 @@ class Context(ContextObject):
 
 @dataclass
 class AsyncContext(Context):
+    """
+    Represents the context in which an asynchronous :class:`SlashCommand` is
+    invoked. Also provides coroutine functions to handle followup messages.
+
+    Users should not need to instantiate this class manually.
+    """
+
     def __post_init__(self):
         self.session = aiohttp.ClientSession(
             headers=self.auth_headers,

--- a/flask_discord_interactions/response.py
+++ b/flask_discord_interactions/response.py
@@ -1,4 +1,5 @@
 import json
+import inspect
 import dataclasses
 from typing import List, Union
 
@@ -116,8 +117,13 @@ class Response:
             The function return value to convert into a ``Response`` object.
         """
 
+        async def construct_async(result):
+            return cls.from_return_value(await result)
+
         if result is None:
             return cls()
+        elif inspect.isawaitable(result):
+            return construct_async(result)
         elif isinstance(result, cls):
             return result
         else:

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md") as file:
 
 setup(
     name='Flask-Discord-Interactions',
-    version='0.1.9',
+    version='0.1.10',
     url='https://github.com/Breq16/flask-discord-interactions',
     author='Brooke Chalmers',
     author_email='breq@breq.dev',
@@ -23,6 +23,9 @@ setup(
         "requests",
         "PyNaCl"
     ],
+    extras_require={
+        "async": ["Quart", "aiohttp"]
+    },
     tests_require=["pytest"],
     classifiers=[
         'Environment :: Web Environment',


### PR DESCRIPTION
This PR adds support for asynchronous commands using Quart. This works for both immediate and followup responses.

```python
@discord.command()
async def ping(ctx):
    "Respond with a friendly 'pong'!"
    return "Pong!"
```

```python
import asyncio

@discord.command()
async def wait(ctx, seconds: int):

    async def do_followup():
        await asyncio.sleep(seconds)
        await ctx.edit("Done!")
        await ctx.close()

    asyncio.create_task(do_followup())
    return Response(deferred=True)
```

Apps using Quart must be created as:
```python
from quart import Quart

import quart.flask_patch
from flask_discord_interactions import DiscordInteractions

app = Quart(__name__)
discord = DiscordInteractions(app)
```

The library takes advantage of Quart's monkey-patching (`quart.flask_patch`) to support both Flask and Quart.

Flask apps should not be affected by these changes.