### PR TITLE
Add testing, add'l docs for Quart support

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install flake8 pytest pytest-cov sphinx
+        pip install flake8 pytest pytest-cov pytest-asyncio quart sphinx
         pip install -r requirements.txt
     - name: Lint with flake8
       run: |

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,7 +1,7 @@
 Flask-Discord-Interactions
 ==========================
 
-Flask-Discord-Interactions is a Flask extension that lets you write Discord Slash Commands using a decorator syntax similar to Flask's ``@app.route()`` or Discord.py's ``@bot.command()``.
+Flask-Discord-Interactions is a Flask (or `Quart <https://pgjones.gitlab.io/quart/>`_) extension that lets you write Discord Slash Commands using a decorator syntax similar to Flask's ``@app.route()`` or Discord.py's ``@bot.command()``.
 
 .. code-block:: python
 
@@ -19,6 +19,7 @@ Features
 - Add Discord commands to a Flask app
 - Handle webhook verification
 - Send followup messages with webhooks
+- Use ``async``/``await`` (with Quart)
 
 Installation
 ------------

--- a/flask_discord_interactions/tests/test_quart.py
+++ b/flask_discord_interactions/tests/test_quart.py
@@ -1,0 +1,43 @@
+import asyncio
+
+import pytest
+
+@pytest.fixture()
+def quart_discord():
+    import sys
+    del sys.modules["flask"]
+
+    from quart import Quart
+    import quart.flask_patch
+
+
+    from flask_discord_interactions import DiscordInteractions, Client
+
+
+    app = Quart(__name__)
+    discord = DiscordInteractions(app)
+    return discord, Client(discord)
+
+
+@pytest.mark.asyncio
+async def test_async_ping(quart_discord):
+    discord, client = quart_discord
+
+    @discord.command()
+    async def ping(ctx, pong: str = "pong"):
+        "Respond with a friendly 'pong'!"
+        return f"Pong {pong}!"
+
+    assert (await client.run("ping")).content == "Pong pong!"
+
+
+@pytest.mark.asyncio
+async def test_await_in_command(quart_discord):
+    discord, client = quart_discord
+
+    @discord.command()
+    async def wait(ctx):
+        await asyncio.sleep(0.01)
+        return "Hi!"
+
+    assert (await client.run("wait")).content == "Hi!"

--- a/flask_discord_interactions/tests/test_quart.py
+++ b/flask_discord_interactions/tests/test_quart.py
@@ -5,7 +5,8 @@ import pytest
 @pytest.fixture()
 def quart_discord():
     import sys
-    del sys.modules["flask"]
+    if "flask" in sys.modules:
+        del sys.modules["flask"]
 
     from quart import Quart
     import quart.flask_patch
@@ -41,3 +42,18 @@ async def test_await_in_command(quart_discord):
         return "Hi!"
 
     assert (await client.run("wait")).content == "Hi!"
+
+@pytest.mark.asyncio
+async def test_mixed_commands(quart_discord):
+    discord, client = quart_discord
+
+    @discord.command()
+    async def async_command(ctx):
+        return "Async"
+
+    @discord.command()
+    def not_async_command(ctx):
+        return "Not Async"
+
+    assert (await client.run("async_command")).content == "Async"
+    assert client.run("not_async_command").content == "Not Async"


### PR DESCRIPTION
The Quart support previously had no testing--this PR adds testing for the declaration of async commands (but not `AsyncContext`). This also adds some discussion of Quart on the main documentation page.