### PR TITLE
Support for Message Components

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -7,7 +7,6 @@ API Reference
     discord.rst
     command.rst
     context.rst
-    debugging.rst
     options.rst
     response.rst
     client.rst

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -11,4 +11,5 @@ API Reference
     options.rst
     response.rst
     client.rst
+    components.rst
     quart.rst

--- a/docs/components.rst
+++ b/docs/components.rst
@@ -1,0 +1,161 @@
+Message Components
+==================
+
+
+Message components allow you to include clickable buttons in messages from your
+bot. The documentation on
+`Discord <https://discord.com/developers/docs/interactions/message-components>`_
+covers their general use.
+
+To use these components with Flask-Discord-Interactions, you can use the
+:class:`.ActionRow` and :class:`.Button` classes.
+
+Link Buttons
+------------
+
+Link buttons are the simplest example, as they don't require any special
+handling. When the button is clicked, the user is sent to the link.
+
+.. code-block:: python
+
+    from flask_discord_interactions import Response, ActionRow, Button
+
+    @discord.command()
+    def google(ctx):
+        return Response(
+            content="search engine",
+            components=[
+                ActionRow(components=[
+                    Button(
+                        style=ButtonStyles.LINK,
+                        url="https://www.google.com/",
+                        label="Go to google"
+                    )
+                ])
+            ]
+        )
+
+Link buttons require ``style`` to be set to :attr:`.ButtonStyles.LINK`.
+
+Non-Link Buttons
+----------------
+
+Buttons can also send out additional Interactions when clicked. To handle these
+additional interactions, Flask-Discord-Interactions requires defining handler
+functions.
+
+These handler functions return a :class:`.Response`, but this response can also
+have the ``update`` parameter set. With ``update=True``, the new Response will
+replace the original message (the one with the button that triggered the
+handler).
+
+You can register a handler using the :meth:`.DiscordInteractions.custom_handler`
+decorator, like so:
+
+    In this example, a global variable is used to keep track of the count. This
+    is a `bad idea <https://stackoverflow.com/questions/32815451/>`_. You would
+    probably use a database for this instead.
+
+
+.. code-block:: python
+
+    click_count = 0
+
+    @discord.custom_handler()
+    def handle_click(ctx):
+        global click_count
+        click_count += 1
+
+        return Response(
+            content=f"The button has been clicked {click_count} times",
+            components=[
+                ActionRow(components=[
+                    Button(
+                        style=ButtonStyles.PRIMARY,
+                        custom_id=handle_click,
+                        label="Click Me!"
+                    )
+                ])
+            ],
+            update=True
+        )
+
+    @discord.command()
+    def click_counter(ctx):
+        "Count the number of button clicks"
+
+        return Response(
+            content=f"The button has been clicked {click_count} times",
+            components=[
+                ActionRow(components=[
+                    Button(
+                        style=ButtonStyles.PRIMARY,
+                        custom_id=handle_click,
+                        label="Click Me!"
+                    )
+                ])
+            ]
+        )
+
+Custom IDs
+----------
+
+Custom IDs are used to uniquely identify a button. Thus, when a web server
+receives an incoming interaction, it can use the custom ID to determine what
+button triggered it.
+
+Discord allows Custom IDs to be any string that is 100 characters or less
+(`relevant docs <https://discord.com/developers/docs/interactions/message-components#custom-id>`_).
+However, you may have noticed that the snippets above do not explicitly specify
+a custom ID string. Instead, the handler function *appears* to be passed
+directly to the ``custom_id`` field. How is this possible?
+
+The trick is, the :meth:`.DiscordInteractions.custom_handler` decorator will
+actually generate a custom ID string (a :py:func:`uuid.uuid4`). It will return
+this custom ID string in place of the function, after it adds it to the
+internal :attr:`.DiscordInteractions.custom_id_handlers` attribute.
+This means that the line ``custom_id=handle_click`` is actually passing a
+string to the :class:`.Button` constructor.
+
+The reason behind this trickery is to abstract away the details of custom IDs
+from the developer. Buttons will just map directly to their handler functions.
+However, if you want more control, there is an escape hatch: the
+:meth:`.DiscordInteractions.custom_handler` decorator accepts a ``custom_id``
+parameter which will override the ID given. Alternatively, you can use the
+:meth:`.DiscordInteractions.add_custom_handler` function to avoid the decorator
+syntax entirely.
+
+
+Full API
+--------
+
+.. autoclass:: flask_discord_interactions.Component
+    :members:
+
+|
+
+.. autoclass:: flask_discord_interactions.ComponentType
+    :members:
+    :undoc-members:
+    :member-order: bysource
+
+|
+
+.. autoclass:: flask_discord_interactions.ActionRow(**kwargs)
+    :show-inheritance:
+    :members:
+    :undoc-members:
+
+|
+
+.. autoclass:: flask_discord_interactions.Button(**kwargs)
+    :show-inheritance:
+    :members:
+    :undoc-members:
+
+|
+
+.. autoclass:: flask_discord_interactions.ButtonStyles
+    :members:
+    :undoc-members:
+    :member-order: bysource

--- a/docs/debugging.rst
+++ b/docs/debugging.rst
@@ -74,6 +74,7 @@ for this example to work.
 .. code-block:: sh
 
     $ curl --location --request POST 'http://127.0.0.1:5000/interactions' --header 'Content-Type: application/json' --data-raw '{
+        "type": 2,
         "id": 1,
         "channel_id": "",
         "guild_id": "",

--- a/examples/components.py
+++ b/examples/components.py
@@ -35,7 +35,20 @@ click_count = 0
 def handle_click(ctx):
     global click_count
     click_count += 1
-    return "Click counted!"
+
+    return Response(
+        content=f"The button has been clicked {click_count} times",
+        components=[
+            ActionRow(components=[
+                Button(
+                    style=ButtonStyles.PRIMARY,
+                    custom_id=handle_click,
+                    label="Click Me!"
+                )
+            ])
+        ],
+        update=True
+    )
 
 
 @discord.command()
@@ -56,28 +69,22 @@ def click_counter(ctx):
     )
 
 
-current_score = 0
-
 @discord.custom_handler()
 def handle_upvote(ctx):
-    global current_score
-    current_score += 1
     return f"Upvote by {ctx.author.display_name}!"
 
 
 @discord.custom_handler()
 def handle_downvote(ctx):
-    global current_score
-    current_score -= 1
     return f"Downvote by {ctx.author.display_name}!"
 
 
 @discord.command()
-def voting(ctx):
-    "Count the number of button clicks"
+def voting(ctx, question: str):
+    "Vote on something!"
 
     return Response(
-        content=f"Current score: {current_score}",
+        content=f"The question is: {question}",
         components=[
             ActionRow(components=[
                 Button(

--- a/examples/components.py
+++ b/examples/components.py
@@ -1,0 +1,82 @@
+import os
+import sys
+
+from flask import Flask
+
+# This is just here for the sake of examples testing
+# to make sure that the imports work
+# (you don't actually need it in your code)
+sys.path.insert(1, ".")
+
+from flask_discord_interactions import (DiscordInteractions,  # noqa: E402
+                                        Response, ActionRow, Button,
+                                        ButtonStyles)
+
+
+app = Flask(__name__)
+discord = DiscordInteractions(app)
+
+app.config["DISCORD_CLIENT_ID"] = os.environ["DISCORD_CLIENT_ID"]
+app.config["DISCORD_PUBLIC_KEY"] = os.environ["DISCORD_PUBLIC_KEY"]
+app.config["DISCORD_CLIENT_SECRET"] = os.environ["DISCORD_CLIENT_SECRET"]
+
+
+discord.update_slash_commands()
+
+
+@discord.command()
+def click_counter(ctx):
+    "Count the number of button clicks"
+
+    count = 0
+
+    return Response(
+        content=f"The button has been clicked {count} times",
+        components=[
+            ActionRow(components=[
+                Button(
+                    style=ButtonStyles.PRIMARY,
+                    custom_id="my_test_button",
+                    label="Click Me!"
+                )
+            ])
+        ]
+    )
+
+
+@discord.command()
+def voting(ctx):
+    "Count the number of button clicks"
+
+    upvotes = 0
+    downvotes = 0
+
+    return Response(
+        content=f"{upvotes} upvotes, {downvotes} downvotes",
+        components=[
+            ActionRow(components=[
+                Button(
+                    style=ButtonStyles.SUCCESS,
+                    custom_id="voting_upvote",
+                    emoji={
+                        "name": "⬆️"
+                    }
+                ),
+                Button(
+                    style=ButtonStyles.DANGER,
+                    custom_id="voting_downvote",
+                    emoji={
+                        "name": "⬇️",
+                    }
+                )
+            ])
+        ]
+    )
+
+
+discord.set_route("/interactions")
+discord.update_slash_commands(guild_id=os.environ["TESTING_GUILD"])
+
+
+if __name__ == '__main__':
+    app.run()

--- a/examples/components.py
+++ b/examples/components.py
@@ -10,7 +10,7 @@ sys.path.insert(1, ".")
 
 from flask_discord_interactions import (DiscordInteractions,  # noqa: E402
                                         Response, ActionRow, Button,
-                                        ButtonStyles)
+                                        ButtonStyles, Embed)
 
 
 app = Flask(__name__)
@@ -31,6 +31,8 @@ discord.update_slash_commands()
 click_count = 0
 
 
+# The handler edits the original response by setting update=True
+# It sets the action for the button with custom_id
 @discord.custom_handler()
 def handle_click(ctx):
     global click_count
@@ -51,6 +53,7 @@ def handle_click(ctx):
     )
 
 
+# The main command sends the initial Response
 @discord.command()
 def click_counter(ctx):
     "Count the number of button clicks"
@@ -69,10 +72,10 @@ def click_counter(ctx):
     )
 
 
+# You can also return a normal message
 @discord.custom_handler()
 def handle_upvote(ctx):
     return f"Upvote by {ctx.author.display_name}!"
-
 
 @discord.custom_handler()
 def handle_downvote(ctx):
@@ -100,6 +103,73 @@ def voting(ctx, question: str):
                     emoji={
                         "name": "⬇️",
                     }
+                )
+            ])
+        ]
+    )
+
+
+# Ephemeral messages and embeds work
+@discord.custom_handler()
+def handle_avatar_view(ctx):
+    return Response(
+        embed=Embed(
+            title=f"{ctx.author.display_name}",
+            description=f"{ctx.author.username}#{ctx.author.discriminator}"
+        ),
+        ephemeral=True
+    )
+
+@discord.command()
+def username(ctx):
+    "Show your username and discriminator"
+
+    return Response(
+        content="Show user info!",
+        components=[
+            ActionRow(components=[
+                Button(
+                    style=ButtonStyles.PRIMARY,
+                    custom_id=handle_avatar_view,
+                    label="View User!"
+                )
+            ])
+        ]
+    )
+
+
+# Return nothing for no action
+@discord.custom_handler()
+def handle_do_nothing(ctx):
+    print("Doing nothing...")
+
+@discord.command()
+def do_nothing(ctx):
+    return Response(
+        content="Do nothing",
+        components=[
+            ActionRow(components=[
+                Button(
+                    style=ButtonStyles.PRIMARY,
+                    custom_id=handle_do_nothing,
+                    label="Nothing at all!"
+                )
+            ])
+        ]
+    )
+
+
+# Link buttons don't need a handler
+@discord.command()
+def google(ctx):
+    return Response(
+        content="search engine",
+        components=[
+            ActionRow(components=[
+                Button(
+                    style=ButtonStyles.LINK,
+                    url="https://www.google.com/",
+                    label="Go to google"
                 )
             ])
         ]

--- a/flask_discord_interactions/__init__.py
+++ b/flask_discord_interactions/__init__.py
@@ -16,6 +16,7 @@ from flask_discord_interactions.context import (
 )
 
 from flask_discord_interactions.discord import (
+    InteractionType,
     DiscordInteractions,
     DiscordInteractionsBlueprint
 )
@@ -52,6 +53,7 @@ __all__ = [
     "User",
     "Role",
     "Channel",
+    "InteractionType",
     "DiscordInteractions",
     "DiscordInteractionsBlueprint",
     "Response",

--- a/flask_discord_interactions/__init__.py
+++ b/flask_discord_interactions/__init__.py
@@ -23,6 +23,13 @@ from flask_discord_interactions.discord import (
 from flask_discord_interactions.response import Response, ResponseType
 import flask_discord_interactions.embed as embed
 from flask_discord_interactions.embed import Embed
+from flask_discord_interactions.component import (
+    Component,
+    ActionRow,
+    Button,
+    ButtonStyles,
+    ComponentType
+)
 from flask_discord_interactions.client import Client
 
 
@@ -50,6 +57,11 @@ __all__ = [
     "Response",
     "ResponseType",
     "Embed",
+    "Component",
+    "ComponentType",
+    "ActionRow",
+    "Button",
+    "ButtonStyles",
     "Client",
 
     "InteractionResponse",

--- a/flask_discord_interactions/component.py
+++ b/flask_discord_interactions/component.py
@@ -44,7 +44,7 @@ class ButtonStyles:
 class Button(Component):
     "Represents a Button message component."
     style: int
-    custom_id: str
+    custom_id: str = None
     label: str = None
 
     emoji: dict = None
@@ -52,3 +52,11 @@ class Button(Component):
     disabled: bool = False
 
     type: int = ComponentType.BUTTON
+
+    def __post_init__(self):
+        if self.style == ButtonStyles.LINK:
+            if self.url is None:
+                raise ValueError("Link buttons require a url")
+        else:
+            if self.custom_id is None:
+                raise ValueError("Buttons require custom_id")

--- a/flask_discord_interactions/component.py
+++ b/flask_discord_interactions/component.py
@@ -1,0 +1,54 @@
+from dataclasses import dataclass, asdict
+from typing import List
+
+class ComponentType:
+    ACTION_ROW = 1
+    BUTTON = 2
+
+
+class Component:
+    "Represents a Message Component."
+
+    def dump(self):
+        "Returns this Component as a dictionary, removing fields which are None."
+        def filter_none(d):
+            if isinstance(d, dict):
+                return {
+                    k: filter_none(v) for k, v in d.items() if v is not None
+                }
+            elif isinstance(d, list):
+                return [filter_none(v) for v in d if v is not None]
+            else:
+                return d
+
+        return filter_none(asdict(self))
+
+
+@dataclass
+class ActionRow(Component):
+    "Represents an ActionRow message component."
+    components: List[Component] = None
+
+    type: int = ComponentType.ACTION_ROW
+
+
+class ButtonStyles:
+    PRIMARY = 1
+    SECONDARY = 2
+    SUCCESS = 3
+    DANGER = 4
+    LINK = 5
+
+
+@dataclass
+class Button(Component):
+    "Represents a Button message component."
+    style: int
+    custom_id: str
+    label: str = None
+
+    emoji: dict = None
+    url: str = None
+    disabled: bool = False
+
+    type: int = ComponentType.BUTTON

--- a/flask_discord_interactions/context.py
+++ b/flask_discord_interactions/context.py
@@ -215,7 +215,8 @@ class Role(ContextObject):
 @dataclass
 class Context(ContextObject):
     """
-    Represents the context in which a :class:`SlashCommand` is invoked.
+    Represents the context in which a :class:`SlashCommand` or custom ID
+    handler is invoked.
 
     Attributes
     ----------

--- a/flask_discord_interactions/discord.py
+++ b/flask_discord_interactions/discord.py
@@ -1,5 +1,6 @@
 import time
 import inspect
+import uuid
 
 import requests
 
@@ -9,7 +10,8 @@ from nacl.exceptions import BadSignatureError
 from nacl.signing import VerifyKey
 
 from flask_discord_interactions.command import SlashCommand, SlashCommandGroup
-from flask_discord_interactions.response import ResponseType
+from flask_discord_interactions.context import Context
+from flask_discord_interactions.response import Response, ResponseType
 
 
 class InteractionType:
@@ -26,6 +28,7 @@ class DiscordInteractionsBlueprint:
     """
     def __init__(self):
         self.discord_commands = {}
+        self.custom_id_handlers = {}
 
     def add_slash_command(self, command, name=None,
                           description=None, options=None, annotations=None):
@@ -94,6 +97,46 @@ class DiscordInteractionsBlueprint:
         self.discord_commands[name] = group
         return group
 
+    def add_custom_handler(self, handler, custom_id=None):
+        """
+        Add a handler for an incoming interaction with the specified custom ID.
+
+        Parameters
+        ----------
+        handler
+            The function to call to handle the incoming interaction.
+        custom_id
+            The custom ID to respond to. If not specified, the ID will be
+            generated randomly.
+
+        Returns
+        -------
+        str
+            The custom ID that the handler will respond to.
+        """
+        if custom_id is None:
+            custom_id = str(uuid.uuid4())
+
+        self.custom_id_handlers[custom_id] = handler
+        return custom_id
+
+    def custom_handler(self, custom_id=None):
+        """
+        Retuens a decorator to register a handler for a custom ID.
+
+        Parameters
+        ----------
+        custom_id
+            The custom ID to respond to. If not specified, the ID will be
+            generated randomly.
+        """
+        def decorator(func):
+            nonlocal custom_id
+            custom_id = self.add_custom_handler(func, custom_id)
+            return custom_id
+
+        return decorator
+
 
 class DiscordInteractions(DiscordInteractionsBlueprint):
     """
@@ -126,6 +169,7 @@ class DiscordInteractions(DiscordInteractionsBlueprint):
         app.config.setdefault("DONT_VALIDATE_SIGNATURE", False)
         app.config.setdefault("DONT_REGISTER_WITH_DISCORD", False)
         app.discord_commands = self.discord_commands
+        app.custom_id_handlers = self.custom_id_handlers
         app.discord_token = None
 
     def fetch_token(self, app=None):
@@ -272,6 +316,7 @@ class DiscordInteractions(DiscordInteractionsBlueprint):
             app = self.app
 
         app.discord_commands.update(blueprint.discord_commands)
+        app.custom_id_handlers.update(blueprint.custom_id_handlers)
 
     def run_command(self, data):
         """
@@ -292,6 +337,25 @@ class DiscordInteractions(DiscordInteractionsBlueprint):
             raise ValueError(f"Invalid command name: {command_name}")
 
         return slash_command.make_context_and_run(self, current_app, data)
+
+    def run_handler(self, data):
+        """
+        Run the corresponding custom ID handler given incoming interaction
+        data.
+
+        Parameters
+        ----------
+        data
+            Incoming interaction data.
+        """
+
+        custom_id = data["data"]["custom_id"]
+        context = Context.from_data(self, current_app, data)
+
+        result = self.custom_id_handlers[custom_id](context)
+
+        return Response.from_return_value(result)
+
 
     def verify_signature(self, request):
         """
@@ -344,10 +408,15 @@ class DiscordInteractions(DiscordInteractionsBlueprint):
         def interactions():
             self.verify_signature(request)
 
-            if request.json.get("type") == InteractionType.PING:
+            interaction_type = request.json.get("type")
+            if interaction_type == InteractionType.PING:
                 return jsonify({"type": ResponseType.PONG})
 
-            return jsonify(self.run_command(request.json).dump())
+            elif interaction_type == InteractionType.APPLICATION_COMMAND:
+                return jsonify(self.run_command(request.json).dump())
+
+            elif interaction_type == InteractionType.MESSAGE_COMPONENT:
+                return jsonify(self.run_handler(request.json).dump())
 
     def set_route_async(self, route, app=None):
         """
@@ -369,10 +438,15 @@ class DiscordInteractions(DiscordInteractionsBlueprint):
         async def interactions():
             self.verify_signature(request)
 
-            if request.json.get("type") == InteractionType.PING:
+            interaction_type = request.json.get("type")
+            if interaction_type == InteractionType.PING:
                 return jsonify({"type": ResponseType.PONG})
 
-            result = self.run_command(request.json)
+            elif interaction_type == InteractionType.APPLICATION_COMMAND:
+                result = self.run_command(request.json)
+            elif interaction_type == InteractionType.MESSAGE_COMPONENT:
+                result = self.run_handler(request.json)
+
             if inspect.isawaitable(result):
                 result = await result
 

--- a/flask_discord_interactions/discord.py
+++ b/flask_discord_interactions/discord.py
@@ -416,7 +416,7 @@ class DiscordInteractions(DiscordInteractionsBlueprint):
                 return jsonify(self.run_command(request.json).dump())
 
             elif interaction_type == InteractionType.MESSAGE_COMPONENT:
-                return jsonify(self.run_handler(request.json).dump())
+                return jsonify(self.run_handler(request.json).dump_handler())
 
     def set_route_async(self, route, app=None):
         """

--- a/flask_discord_interactions/discord.py
+++ b/flask_discord_interactions/discord.py
@@ -15,6 +15,7 @@ from flask_discord_interactions.response import ResponseType
 class InteractionType:
     PING = 1
     APPLICATION_COMMAND = 2
+    MESSAGE_COMPONENT = 3
 
 
 class DiscordInteractionsBlueprint:

--- a/flask_discord_interactions/response.py
+++ b/flask_discord_interactions/response.py
@@ -12,6 +12,8 @@ class ResponseType:
     PONG = 1
     CHANNEL_MESSAGE_WITH_SOURCE = 4
     DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE = 5
+    DEFERRED_UPDATE_MESSAGE = 6
+    UPDATE_MESSAGE = 7
 
 
 @dataclasses.dataclass

--- a/flask_discord_interactions/response.py
+++ b/flask_discord_interactions/response.py
@@ -43,7 +43,10 @@ class Response:
     ephemeral
         Whether the message should be ephemeral (only displayed temporarily
         to only the user who used the slash command). Only valid for incoming
-        webhooks. You cannot use embeds with ephemeral messages.
+        webhooks.
+    update
+        Whether to update the initial message. Only valid for Message Component
+        interactions / custom ID handlers.
     file
         The file to attach to the message. Only valid for outgoing webhooks.
     files
@@ -61,6 +64,7 @@ class Response:
         default_factory=lambda: {"parse": ["roles", "users", "everyone"]})
     deferred: bool = False
     ephemeral: bool = False
+    update: bool = False
     file: tuple = None
     files: List[tuple] = None
     components: List[Component] = None
@@ -76,11 +80,6 @@ class Response:
         if self.file is not None:
             self.files = [self.file]
 
-        if (self.content is None and self.embeds is None
-                and self.files is None and not self.deferred):
-            raise ValueError(
-                "Supply at least one of content, embeds, files, or deferred.")
-
         if self.ephemeral and self.files is not None:
             raise ValueError("Ephemeral responses cannot include files.")
 
@@ -89,13 +88,21 @@ class Response:
                 if not dataclasses.is_dataclass(embed):
                     self.embeds[i] = Embed(**embed)
 
-    @property
-    def response_type(self):
-        "The Discord response type of the Interaction response."
-        if self.deferred:
-            return ResponseType.DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE
+        if self.update:
+            if self.deferred:
+                self.response_type = ResponseType.DEFERRED_UPDATE_MESSAGE
+            else:
+                self.response_type = ResponseType.UPDATE_MESSAGE
         else:
-            return ResponseType.CHANNEL_MESSAGE_WITH_SOURCE
+            if (self.content is None and self.embeds is None
+                    and self.files is None):
+                # Special case: handler function returns nothing
+                self.response_type = ResponseType.DEFERRED_UPDATE_MESSAGE
+            elif self.deferred:
+                self.response_type = \
+                    ResponseType.DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE
+            else:
+                self.response_type = ResponseType.CHANNEL_MESSAGE_WITH_SOURCE
 
     @property
     def flags(self):
@@ -144,9 +151,17 @@ class Response:
         incoming webhook.
         """
 
+        if (self.content is None and self.embeds is None
+                and self.files is None and not self.deferred):
+            raise ValueError(
+                "Supply at least one of content, embeds, files, or deferred.")
+
         if self.files:
             raise ValueError(
                 "files are not allowed in an initial Interaction response")
+
+        if self.update:
+            raise ValueError("update is only valid for custom ID handlers")
 
         return {
             "type": self.response_type,
@@ -160,12 +175,40 @@ class Response:
             }
         }
 
+    def dump_handler(self):
+        """
+        Return this ``Response`` as a dict to be sent in reply to a Message
+        Component interaction.
+        """
+
+        if self.files:
+            raise ValueError(
+                "files are not allowed in a custom handler response")
+
+        return {
+            "type": self.response_type,
+            "data": {
+                "content": self.content,
+                "tts": self.tts,
+                "embeds": self.dump_embeds(),
+                "allowed_mentions": self.allowed_mentions,
+                "flags": self.flags,
+                "components": self.dump_components()
+            }
+        }
+
+
     def dump_followup(self):
         """
         Return this ``Response`` as a dict to be sent to an outgoing webhook.
         """
 
-        if self.ephemeral or self.deferred:
+        if (self.content is None and self.embeds is None
+                and self.files is None and not self.deferred):
+            raise ValueError(
+                "Supply at least one of content, embeds, files, or deferred.")
+
+        if self.ephemeral or self.deferred or self.update:
             raise ValueError(
                 "ephemeral and deferred are not valid in followup responses")
 

--- a/flask_discord_interactions/response.py
+++ b/flask_discord_interactions/response.py
@@ -5,6 +5,7 @@ from typing import List, Union
 
 
 from flask_discord_interactions.embed import Embed
+from flask_discord_interactions.component import Component
 
 
 class ResponseType:
@@ -48,6 +49,9 @@ class Response:
     files
         An array of files to attach to the message. Speficy just one of
         ``file`` or ``files``. Only valid for outgoing webhooks.
+    components
+        An array of :class:`.Component` objects representing message
+        components.
     """
     content: str = None
     tts: bool = False
@@ -59,6 +63,7 @@ class Response:
     ephemeral: bool = False
     file: tuple = None
     files: List[tuple] = None
+    components: List[Component] = None
 
     def __post_init__(self):
         if self.embed is not None and self.embeds is not None:
@@ -104,6 +109,10 @@ class Response:
         "Returns the embeds of this Response as a list of dicts."
         return [embed.dump() for embed in self.embeds] if self.embeds else None
 
+    def dump_components(self):
+        "Returns the message components as a list of dicts."
+        return [c.dump() for c in self.components] if self.components else None
+
     @classmethod
     def from_return_value(cls, result):
         """
@@ -146,7 +155,8 @@ class Response:
                 "tts": self.tts,
                 "embeds": self.dump_embeds(),
                 "allowed_mentions": self.allowed_mentions,
-                "flags": self.flags
+                "flags": self.flags,
+                "components": self.dump_components()
             }
         }
 
@@ -163,7 +173,8 @@ class Response:
             "content": self.content,
             "tts": self.tts,
             "embeds": self.dump_embeds(),
-            "allowed_mentions": self.allowed_mentions
+            "allowed_mentions": self.allowed_mentions,
+            "components": self.dump_components()
         }
 
     def dump_multipart(self):

--- a/flask_discord_interactions/tests/test_component.py
+++ b/flask_discord_interactions/tests/test_component.py
@@ -1,0 +1,69 @@
+from flask_discord_interactions import (Response, ResponseType, ActionRow,
+                                        Button, ComponentType, ButtonStyles)
+
+
+def test_action_row(discord, client):
+    @discord.command()
+    def action_row(ctx):
+        return Response(
+            content="Hi!",
+            components=[
+                ActionRow()
+            ]
+        )
+
+    expected = {
+        "type": ResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
+        "data": {
+            "content": "Hi!",
+            "embeds": None,
+            "flags": 0,
+            "tts": False,
+            "allowed_mentions": {"parse": ["roles", "users", "everyone"]},
+            "components": [{
+                "type": ComponentType.ACTION_ROW
+            }]
+        }
+    }
+
+    assert client.run("action_row").dump() == expected
+
+
+def test_button(discord, client):
+    @discord.command()
+    def button(ctx):
+        return Response(
+            content="Hi!",
+            components=[
+                ActionRow(components=[
+                    Button(
+                        style=ButtonStyles.PRIMARY,
+                        custom_id="my_button",
+                        label="My Button"
+                    )
+                ])
+            ]
+        )
+
+    expected = {
+        "type": ResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
+        "data": {
+            "content": "Hi!",
+            "embeds": None,
+            "flags": 0,
+            "tts": False,
+            "allowed_mentions": {"parse": ["roles", "users", "everyone"]},
+            "components": [{
+                "type": ComponentType.ACTION_ROW,
+                "components": [{
+                    "type": ComponentType.BUTTON,
+                    "style": ButtonStyles.PRIMARY,
+                    "custom_id": "my_button",
+                    "label": "My Button",
+                    "disabled": False
+                }]
+            }]
+        }
+    }
+
+    assert client.run("button").dump() == expected

--- a/flask_discord_interactions/tests/test_flask.py
+++ b/flask_discord_interactions/tests/test_flask.py
@@ -1,6 +1,6 @@
 from flask import Flask
 
-from flask_discord_interactions import DiscordInteractions, ResponseType
+from flask_discord_interactions import DiscordInteractions, ResponseType, InteractionType
 
 
 def test_flask():
@@ -18,6 +18,7 @@ def test_flask():
 
     with app.test_client() as client:
         response = client.post("/interactions", json={
+            "type": InteractionType.APPLICATION_COMMAND,
             "id": 1,
             "channel_id": "",
             "guild_id": "",
@@ -67,6 +68,7 @@ def test_app_factory():
 
     with app.test_client() as client:
         response = client.post("/interactions", json={
+            "type": InteractionType.APPLICATION_COMMAND,
             "id": 1,
             "channel_id": "",
             "guild_id": "",

--- a/flask_discord_interactions/tests/test_handler.py
+++ b/flask_discord_interactions/tests/test_handler.py
@@ -1,0 +1,48 @@
+from flask_discord_interactions import (Response, ActionRow, Button,
+                                        ButtonStyles)
+
+
+def test_basic_handler(discord, client):
+    click_count = 0
+
+    @discord.custom_handler()
+    def handle_click(ctx):
+        nonlocal click_count
+        click_count += 1
+
+        return Response(
+            content=f"The button has been clicked {click_count} times",
+            components=[
+                ActionRow(components=[
+                    Button(
+                        style=ButtonStyles.PRIMARY,
+                        custom_id=handle_click,
+                        label="Click Me!"
+                    )
+                ])
+            ],
+            update=True
+        )
+
+
+    # The main command sends the initial Response
+    @discord.command()
+    def click_counter(ctx):
+        "Count the number of button clicks"
+
+        return Response(
+            content=f"The button has been clicked {click_count} times",
+            components=[
+                ActionRow(components=[
+                    Button(
+                        style=ButtonStyles.PRIMARY,
+                        custom_id=handle_click,
+                        label="Click Me!"
+                    )
+                ])
+            ]
+        )
+
+    client.run("click_counter")
+    discord.custom_id_handlers[handle_click](None)
+    assert click_count == 1

--- a/flask_discord_interactions/tests/test_response.py
+++ b/flask_discord_interactions/tests/test_response.py
@@ -108,7 +108,8 @@ def test_dump_immediate(discord, client):
             }],
             "flags": 0,
             "tts": True,
-            "allowed_mentions": {"parse": ["roles", "users", "everyone"]}
+            "allowed_mentions": {"parse": ["roles", "users", "everyone"]},
+            "components": None
         }
     }
 
@@ -127,7 +128,8 @@ def test_dump_followup():
             "title": "hello!"
         }],
         "tts": False,
-        "allowed_mentions": {"parse": ["roles", "users", "everyone"]}
+        "allowed_mentions": {"parse": ["roles", "users", "everyone"]},
+        "components": None
     }
 
     assert resp.dump_followup() == expected
@@ -149,7 +151,8 @@ def test_dump_multipart():
                 "embeds": [{
                     "title": "hello!"
                 }],
-                "allowed_mentions": {"parse": ["roles", "users", "everyone"]}
+                "allowed_mentions": {"parse": ["roles", "users", "everyone"]},
+                "components": None
             })
         },
         "files": [


### PR DESCRIPTION
This PR introduces a new API for message components. The full details are located in `docs/components.rst`, but here is the gist of the API:

```python
click_count = 0

@discord.custom_handler()
def handle_click(ctx):
    global click_count
    click_count += 1

    return Response(
        content=f"The button has been clicked {click_count} times",
        components=[
            ActionRow(components=[
                Button(
                    style=ButtonStyles.PRIMARY,
                    custom_id=handle_click,
                    label="Click Me!"
                )
            ])
        ],
        update=True
    )

@discord.command()
def click_counter(ctx):
    "Count the number of button clicks"

    return Response(
        content=f"The button has been clicked {click_count} times",
        components=[
            ActionRow(components=[
                Button(
                    style=ButtonStyles.PRIMARY,
                    custom_id=handle_click,
                    label="Click Me!"
                )
            ])
        ]
    )
```

This PR adds:
* New types to `InteractionType` and similar to support the Message Components interactions
* Classes to represent the `ActionRow` and `Button` components
* New fields/methods for the `Response` class to support updating messages from interactions handlers
* New methods for `DiscordInteractionsBlueprint` to support registering handlers for message components interactions

Documentation and testing are also included.