### PR TITLE
Add basic state storage to custom IDs

### DIFF
--- a/examples/components.py
+++ b/examples/components.py
@@ -176,6 +176,48 @@ def google(ctx):
     )
 
 
+# Use a list with the Custom ID to include additional state information
+@discord.custom_handler()
+def handle_stateful(ctx, interaction_id, current_count):
+
+    # Any state gets converted into a string
+    current_count = int(current_count)
+    current_count += 1
+
+    return Response(
+        content=(f"This button has been clicked {current_count} times. "
+                 "Try calling this command multiple times to see--each button "
+                 "count is tracked separately!"),
+        components=[
+            ActionRow(components=[
+                Button(
+                    style=ButtonStyles.PRIMARY,
+                    custom_id=[handle_stateful, interaction_id, current_count],
+                    label="Click Me!"
+                )
+            ])
+        ],
+        update=True
+    )
+
+@discord.command()
+def stateful_click_counter(ctx):
+    "Count the number of button clicks for this specific button."
+
+    return Response(
+        content=f"Click the button!",
+        components=[
+            ActionRow(components=[
+                Button(
+                    style=ButtonStyles.PRIMARY,
+                    custom_id=[handle_stateful, ctx.id, 0],
+                    label="Click Me!"
+                )
+            ])
+        ]
+    )
+
+
 discord.set_route("/interactions")
 discord.update_slash_commands(guild_id=os.environ["TESTING_GUILD"])
 

--- a/examples/components.py
+++ b/examples/components.py
@@ -177,11 +177,9 @@ def google(ctx):
 
 
 # Use a list with the Custom ID to include additional state information
+# Optionally specify the type (e.g. int) to automatically convert
 @discord.custom_handler()
-def handle_stateful(ctx, interaction_id, current_count):
-
-    # Any state gets converted into a string
-    current_count = int(current_count)
+def handle_stateful(ctx, interaction_id, current_count: int):
     current_count += 1
 
     return Response(

--- a/examples/pagination.py
+++ b/examples/pagination.py
@@ -1,0 +1,140 @@
+import os
+import sys
+import datetime
+
+from flask import Flask
+
+# This is just here for the sake of examples testing
+# to make sure that the imports work
+# (you don't actually need it in your code)
+sys.path.insert(1, ".")
+
+from flask_discord_interactions import (DiscordInteractions,  # noqa: E402
+                                        Response, ActionRow, Button,
+                                        ButtonStyles, Embed)
+
+
+app = Flask(__name__)
+discord = DiscordInteractions(app)
+
+app.config["DISCORD_CLIENT_ID"] = os.environ["DISCORD_CLIENT_ID"]
+app.config["DISCORD_PUBLIC_KEY"] = os.environ["DISCORD_PUBLIC_KEY"]
+app.config["DISCORD_CLIENT_SECRET"] = os.environ["DISCORD_CLIENT_SECRET"]
+
+
+discord.update_slash_commands()
+
+
+# STATIC PAGINATION
+
+# You could put actual data here
+# (help page about your bot, etc)
+mock_page_data = [
+    {
+        "title": f"My Embed {i}",
+        "description": f"This is embed number {i}."
+    } for i in range(10)
+]
+
+
+# We use the same action rows in both the initial response and the subsequent
+# edits. Thus, we can define a helper function to reduce code duplication
+def get_page_buttons(*handler):
+    # Split into two ActionRows because you can only have 5 buttons per row
+    handler = list(handler)
+
+    return [
+        ActionRow(components=[
+            Button(
+                style=ButtonStyles.PRIMARY,
+                custom_id=(handler + [i]),
+                label=f"Page {i}"
+            ) for i in range(5)
+        ]),
+        ActionRow(components=[
+            Button(
+                style=ButtonStyles.PRIMARY,
+                custom_id=(handler + [i]),
+                label=f"Page {i}"
+            ) for i in range(5, 10)
+        ])
+    ]
+
+
+@discord.custom_handler()
+def handle_paginated_static(ctx, pageno):
+    pageno = int(pageno)
+
+    return Response(
+        embed=Embed(**mock_page_data[pageno]),
+        components=get_page_buttons(handle_paginated_static),
+        update=True
+    )
+
+
+# The main command sends the initial Response
+@discord.command()
+def paginated_static(ctx):
+    "A simple paginated menu with static data"
+
+    return Response(
+        embed=Embed(title="Click a button to jump to a page!"),
+        components=get_page_buttons(handle_paginated_static)
+    )
+
+
+
+# DYNAMIC PAGINATION
+
+# Here, you have to store each response on the server-side
+# (it probably won't fit into the custom_id state)
+response_data = {}
+
+# This is a bad way to store server-side data, you should use an actual
+# database, you *will* run into threading issues in production otherwise
+
+@discord.custom_handler()
+def handle_paginated_dynamic(ctx, id, pageno):
+    global response_data
+
+    pageno = int(pageno)
+
+    return Response(
+        embed=Embed(**response_data[id][pageno]),
+        components=get_page_buttons(handle_paginated_dynamic, id),
+        update=True
+    )
+
+
+# The main command sends the initial Response
+@discord.command()
+def paginated_dynamic(ctx):
+    "A simple paginated menu with dynamic data"
+    global response_data
+
+    now = datetime.datetime.now()
+
+    # You could put actual data here
+    # (fetch user data from a database or API, etc)
+    response = [
+        {
+            "title": f"Custom Response Page {i}",
+            "description": (f"Fetched just for {ctx.author.display_name} "
+                            f"at {now}!")
+        } for i in range(10)
+    ]
+
+    response_data[ctx.id] = response
+
+    return Response(
+        embed=Embed(**response[0]),
+        components=get_page_buttons(handle_paginated_dynamic, ctx.id)
+    )
+
+
+discord.set_route("/interactions")
+discord.update_slash_commands(guild_id=os.environ["TESTING_GUILD"])
+
+
+if __name__ == '__main__':
+    app.run(threaded=False)

--- a/examples/pagination.py
+++ b/examples/pagination.py
@@ -62,8 +62,7 @@ def get_page_buttons(*handler):
 
 
 @discord.custom_handler()
-def handle_paginated_static(ctx, pageno):
-    pageno = int(pageno)
+def handle_paginated_static(ctx, pageno: int):
 
     return Response(
         embed=Embed(**mock_page_data[pageno]),
@@ -94,10 +93,8 @@ response_data = {}
 # database, you *will* run into threading issues in production otherwise
 
 @discord.custom_handler()
-def handle_paginated_dynamic(ctx, id, pageno):
+def handle_paginated_dynamic(ctx, id, pageno: int):
     global response_data
-
-    pageno = int(pageno)
 
     return Response(
         embed=Embed(**response_data[id][pageno]),

--- a/flask_discord_interactions/component.py
+++ b/flask_discord_interactions/component.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, asdict
-from typing import List
+from typing import List, Union
 
 class ComponentType:
     ACTION_ROW = 1
@@ -44,7 +44,7 @@ class ButtonStyles:
 class Button(Component):
     "Represents a Button message component."
     style: int
-    custom_id: str = None
+    custom_id: Union[str, List] = None
     label: str = None
 
     emoji: dict = None
@@ -60,3 +60,7 @@ class Button(Component):
         else:
             if self.custom_id is None:
                 raise ValueError("Buttons require custom_id")
+
+        if (isinstance(self.custom_id, list)
+                or isinstance(self.custom_id, tuple)):
+            self.custom_id = "\n".join(str(item) for item in self.custom_id)

--- a/flask_discord_interactions/component.py
+++ b/flask_discord_interactions/component.py
@@ -64,3 +64,6 @@ class Button(Component):
         if (isinstance(self.custom_id, list)
                 or isinstance(self.custom_id, tuple)):
             self.custom_id = "\n".join(str(item) for item in self.custom_id)
+
+        if len(self.custom_id) > 100:
+            raise ValueError("custom_id has maximum 100 characters")

--- a/flask_discord_interactions/context.py
+++ b/flask_discord_interactions/context.py
@@ -259,10 +259,16 @@ class Context(ContextObject):
     auth_headers: dict = None
     base_url: str = ""
 
+    custom_id: str = None
+    primary_id: str = None
+    handler_state: list = None
+
     @classmethod
     def from_data(cls, discord=None, app=None, data={}):
         if data is None:
             data = {}
+
+        custom_id = data.get("data", {}).get("custom_id")
 
         result = cls(
             client_id = app.config["DISCORD_CLIENT_ID"] if app else "",
@@ -275,7 +281,10 @@ class Context(ContextObject):
             guild_id = data.get("guild_id"),
             options = data.get("data", {}).get("options"),
             command_name = data.get("data", {}).get("name"),
-            command_id = data.get("data", {}).get("id")
+            command_id = data.get("data", {}).get("id"),
+            custom_id = custom_id,
+            primary_id = custom_id.split("\n", 1)[0] if custom_id else None,
+            handler_state = custom_id.split("\n") if custom_id else None
         )
 
         result.parse_resolved(data.get("data", {}).get("resolved", {}))

--- a/flask_discord_interactions/discord.py
+++ b/flask_discord_interactions/discord.py
@@ -349,10 +349,10 @@ class DiscordInteractions(DiscordInteractionsBlueprint):
             Incoming interaction data.
         """
 
-        custom_id = data["data"]["custom_id"]
         context = Context.from_data(self, current_app, data)
 
-        result = self.custom_id_handlers[custom_id](context)
+        handler = self.custom_id_handlers[context.primary_id]
+        result = handler(context, *context.handler_state[1:])
 
         return Response.from_return_value(result)
 

--- a/flask_discord_interactions/tests/test_handler.py
+++ b/flask_discord_interactions/tests/test_handler.py
@@ -46,3 +46,47 @@ def test_basic_handler(discord, client):
     client.run("click_counter")
     discord.custom_id_handlers[handle_click](None)
     assert click_count == 1
+
+
+def test_stateful_handler(discord, client):
+    @discord.custom_handler()
+    def handle_click(ctx, click_count):
+        click_count = int(click_count)
+        click_count += 1
+
+        return Response(
+            content=f"{click_count} clicks",
+            components=[
+                ActionRow(components=[
+                    Button(
+                        style=ButtonStyles.PRIMARY,
+                        custom_id=[handle_click, click_count],
+                        label="Click Me!"
+                    )
+                ])
+            ],
+            update=True
+        )
+
+
+    # The main command sends the initial Response
+    @discord.command()
+    def click_counter(ctx):
+        "Count the number of button clicks"
+
+        return Response(
+            content=f"The button has been clicked 0 times",
+            components=[
+                ActionRow(components=[
+                    Button(
+                        style=ButtonStyles.PRIMARY,
+                        custom_id=[handle_click, 0],
+                        label="Click Me!"
+                    )
+                ])
+            ]
+        )
+
+    client.run("click_counter")
+    response = discord.custom_id_handlers[handle_click](None, 0)
+    assert response.content == "1 clicks"


### PR DESCRIPTION
Providing a list instead of a string as the custom ID for a Button will join the list items with newlines. Then, when the custom ID is parsed, it will be split by newlines. The first line is used to identify the handler function, and any subsequent lines are passed as arguments to the handler function. Additionally, providing type hints for these arguments will enable automatic type conversion.

Code example:
```python
@discord.custom_handler()
def handle_stateful(ctx, interaction_id, current_count: int):
    current_count += 1

    return Response(
        content=(f"This button has been clicked {current_count} times. "
                 "Try calling this command multiple times to see--each button "
                 "count is tracked separately!"),
        components=[
            ActionRow(components=[
                Button(
                    style=ButtonStyles.PRIMARY,
                    custom_id=[handle_stateful, interaction_id, current_count],
                    label="Click Me!"
                )
            ])
        ],
        update=True
    )

@discord.command()
def stateful_click_counter(ctx):
    "Count the number of button clicks for this specific button."

    return Response(
        content=f"Click the button!",
        components=[
            ActionRow(components=[
                Button(
                    style=ButtonStyles.PRIMARY,
                    custom_id=[handle_stateful, ctx.id, 0],
                    label="Click Me!"
                )
            ])
        ]
    )
```