### PR TITLE
Fix bug in construction of Context objects for subcommand invocation

### DIFF
--- a/examples/subcommands.py
+++ b/examples/subcommands.py
@@ -33,6 +33,20 @@ def homestuck(ctx, number: int):
     return f"https://homestuck.com/story/{number}"
 
 
+# Subcommands have the same access to context
+whatismy = discord.command_group("whatismy")
+
+
+@whatismy.command()
+def name(ctx):
+    return ctx.author.display_name
+
+
+@whatismy.command()
+def discriminator(ctx):
+    return ctx.author.discriminator
+
+
 # Subcommand groups are also supported
 base = discord.command_group("base", "Convert a number between bases")
 

--- a/flask_discord_interactions/command.py
+++ b/flask_discord_interactions/command.py
@@ -276,7 +276,9 @@ class SlashCommandGroup(SlashCommandSubgroup):
         subcommands, kwargs = context.create_args(
             data["data"], resolved=data["data"].get("resolved"))
 
-        return self.run(context, *subcommands, **kwargs)
+        result = self.run(context, *subcommands, **kwargs)
+
+        return Response.from_return_value(result)
 
     def subgroup(self, name, description="No description"):
         """

--- a/flask_discord_interactions/command.py
+++ b/flask_discord_interactions/command.py
@@ -271,7 +271,8 @@ class SlashCommandGroup(SlashCommandSubgroup):
             The incoming interaction data.
         """
 
-        context = Context(discord, app, data)
+        context = Context.from_data(discord, app, data)
+
         subcommands, kwargs = context.create_args(
             data["data"], resolved=data["data"].get("resolved"))
 

--- a/flask_discord_interactions/tests/test_subcommand.py
+++ b/flask_discord_interactions/tests/test_subcommand.py
@@ -1,4 +1,4 @@
-from flask_discord_interactions import CommandOptionType
+from flask_discord_interactions import CommandOptionType, Context, Member
 
 
 def test_subcommand(discord, client):
@@ -75,3 +75,15 @@ def test_oldstyle_subcommand(discord, client):
         "https://google.com/search?q=hello"
     assert client.run("search", "bing", query="hello").content == \
         "https://bing.com/search?q=hello"
+
+def test_context_with_subcommand(discord, client):
+    group = discord.command_group("group")
+
+    @group.command()
+    def subcommand(ctx):
+        return ctx.author.display_name
+
+    context = Context(author=Member(username="Bob"))
+
+    with client.context(context):
+        assert client.run("group", "subcommand").content == "Bob"


### PR DESCRIPTION
This PR fixes an issue with how the library constructs `Context` objects when a subcommand is invoked. It also includes an example of subcommand use with context.

(This PR additionally adds a unit test for use of the `Context` object within a subcommand. However, the test client did not exhibit this bug.)

Closes #29.