### PR TITLE
Fix some issues discovered while troubleshooting subcommand followup issues

### DIFF
--- a/examples/multifile/main.py
+++ b/examples/multifile/main.py
@@ -20,10 +20,12 @@ discord.update_slash_commands()
 
 from echo import bp as echo_bp  # noqa: E402
 from reverse import bp as reverse_bp  # noqa: E402
+from subcommands import bp as subcommands_bp # noqa: E402
 
 
 discord.register_blueprint(echo_bp)
 discord.register_blueprint(reverse_bp)
+discord.register_blueprint(subcommands_bp)
 
 
 discord.set_route("/interactions")

--- a/examples/multifile/subcommands.py
+++ b/examples/multifile/subcommands.py
@@ -1,0 +1,20 @@
+import threading
+
+from flask_discord_interactions import DiscordInteractionsBlueprint, Response
+
+
+bp = DiscordInteractionsBlueprint()
+group = bp.command_group("group", "First Group")
+sub = group.subgroup("sub", "Sub Group")
+
+@sub.command()
+def echo_delay(ctx, text: str):
+    "Repeat a string on a delay"
+
+    def do_searchData():
+        ctx.send(Response(f"*Echooo 2!!!* {text}"))
+
+    thread = threading.Thread(target=do_searchData)
+    thread.start()
+
+    return Response(f"*Echooo 1!!!* {text}")

--- a/examples/subcommands.py
+++ b/examples/subcommands.py
@@ -35,46 +35,6 @@ def homestuck(ctx, number: int):
     return f"https://homestuck.com/story/{number}"
 
 
-# Subcommands have the same access to context
-whatismy = discord.command_group("whatismy")
-
-
-@whatismy.command()
-def name(ctx):
-    return ctx.author.display_name
-
-
-@whatismy.command()
-def discriminator(ctx):
-    return ctx.author.discriminator
-
-# Subcommands can send followup responses too
-delay = discord.command_group("delay")
-
-@delay.command()
-def seconds(ctx, seconds: int):
-    def do_delay():
-        time.sleep(seconds)
-
-        ctx.edit("Hiya!")
-
-    thread = threading.Thread(target=do_delay)
-    thread.start()
-
-    return Response(deferred=True)
-
-@delay.command()
-def minutes(ctx, minutes: str):
-    def do_delay():
-        time.sleep(float(minutes) * 60)
-
-        ctx.edit("Hiya!")
-
-    thread = threading.Thread(target=do_delay)
-    thread.start()
-
-    return Response(deferred=True)
-
 
 # Subcommand groups are also supported
 base = discord.command_group("base", "Convert a number between bases")
@@ -105,6 +65,64 @@ def base_from_bin(ctx, number: str):
 def base_from_hex(ctx, number: str):
     "Convert a number out of hexadecimal"
     return Response(int(number, base=16), ephemeral=True)
+
+
+# Subcommands have the same access to context
+whatismy = discord.command_group("whatismy")
+
+
+@whatismy.command()
+def name(ctx):
+    return ctx.author.display_name
+
+
+@whatismy.command()
+def discriminator(ctx):
+    return ctx.author.discriminator
+
+# And so do subcommands in subcommand groups
+top_level = discord.command_group("toplevel")
+second_level = top_level.subgroup("secondlevel")
+
+@second_level.command()
+def thirdlevel(ctx):
+    def do_delay():
+        time.sleep(1)
+
+        ctx.edit(f"Hello, {ctx.author.display_name}!")
+
+    thread = threading.Thread(target=do_delay)
+    thread.start()
+
+    return Response(deferred=True)
+
+
+# Subcommands can send followup responses too
+delay = discord.command_group("delay")
+
+@delay.command()
+def seconds(ctx, seconds: int):
+    def do_delay():
+        time.sleep(seconds)
+
+        ctx.edit("Hiya!")
+
+    thread = threading.Thread(target=do_delay)
+    thread.start()
+
+    return Response(deferred=True)
+
+@delay.command()
+def minutes(ctx, minutes: str):
+    def do_delay():
+        time.sleep(float(minutes) * 60)
+
+        ctx.edit("Hiya!")
+
+    thread = threading.Thread(target=do_delay)
+    thread.start()
+
+    return Response(deferred=True)
 
 
 discord.set_route("/interactions")

--- a/examples/subcommands.py
+++ b/examples/subcommands.py
@@ -1,5 +1,7 @@
 import os
 import sys
+import time
+import threading
 
 from flask import Flask
 
@@ -45,6 +47,33 @@ def name(ctx):
 @whatismy.command()
 def discriminator(ctx):
     return ctx.author.discriminator
+
+# Subcommands can send followup responses too
+delay = discord.command_group("delay")
+
+@delay.command()
+def seconds(ctx, seconds: int):
+    def do_delay():
+        time.sleep(seconds)
+
+        ctx.edit("Hiya!")
+
+    thread = threading.Thread(target=do_delay)
+    thread.start()
+
+    return Response(deferred=True)
+
+@delay.command()
+def minutes(ctx, minutes: str):
+    def do_delay():
+        time.sleep(float(minutes) * 60)
+
+        ctx.edit("Hiya!")
+
+    thread = threading.Thread(target=do_delay)
+    thread.start()
+
+    return Response(deferred=True)
 
 
 # Subcommand groups are also supported

--- a/flask_discord_interactions/command.py
+++ b/flask_discord_interactions/command.py
@@ -202,6 +202,8 @@ class SlashCommandSubgroup(SlashCommand):
         self.description = description
         self.subcommands = {}
 
+        self.is_async = False
+
     def command(self, name=None, description=None,
                 options=None, annotations=None):
         """

--- a/flask_discord_interactions/component.py
+++ b/flask_discord_interactions/component.py
@@ -65,5 +65,5 @@ class Button(Component):
                 or isinstance(self.custom_id, tuple)):
             self.custom_id = "\n".join(str(item) for item in self.custom_id)
 
-        if len(self.custom_id) > 100:
+        if self.custom_id and len(self.custom_id) > 100:
             raise ValueError("custom_id has maximum 100 characters")

--- a/flask_discord_interactions/context.py
+++ b/flask_discord_interactions/context.py
@@ -338,7 +338,7 @@ class Context(ContextObject):
         """
 
         def create_args_recursive(data, resolved):
-            if "options" not in data:
+            if not data.get("options"):
                 return [], {}
 
             args = []

--- a/flask_discord_interactions/discord.py
+++ b/flask_discord_interactions/discord.py
@@ -353,7 +353,7 @@ class DiscordInteractions(DiscordInteractionsBlueprint):
 
         handler = self.custom_id_handlers[context.primary_id]
 
-        args = context.create_handler_args(data, handler)
+        args = context.create_handler_args(handler)
 
         result = handler(context, *args)
 

--- a/flask_discord_interactions/response.py
+++ b/flask_discord_interactions/response.py
@@ -94,11 +94,7 @@ class Response:
             else:
                 self.response_type = ResponseType.UPDATE_MESSAGE
         else:
-            if (self.content is None and self.embeds is None
-                    and self.files is None):
-                # Special case: handler function returns nothing
-                self.response_type = ResponseType.DEFERRED_UPDATE_MESSAGE
-            elif self.deferred:
+            if self.deferred:
                 self.response_type = \
                     ResponseType.DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE
             else:

--- a/flask_discord_interactions/tests/test_subcommand.py
+++ b/flask_discord_interactions/tests/test_subcommand.py
@@ -95,5 +95,8 @@ def test_followup_with_subcommand(discord, client):
     def subcommand(ctx):
         return ctx.base_url
 
-    assert client.run("group", "subcommand").content == \
-        "https://discord.com/api/v9"
+    context = Context(base_url="https://discord.com/")
+
+    with client.context(context):
+        assert client.run("group", "subcommand").content == \
+            "https://discord.com/"

--- a/flask_discord_interactions/tests/test_subcommand.py
+++ b/flask_discord_interactions/tests/test_subcommand.py
@@ -87,3 +87,13 @@ def test_context_with_subcommand(discord, client):
 
     with client.context(context):
         assert client.run("group", "subcommand").content == "Bob"
+
+def test_followup_with_subcommand(discord, client):
+    group = discord.command_group("group")
+
+    @group.command()
+    def subcommand(ctx):
+        return ctx.base_url
+
+    assert client.run("group", "subcommand").content == \
+        "https://discord.com/api/v9"


### PR DESCRIPTION
In the course of investigating #31, I discovered some bugs:

* Command Groups and Subgroups had no `is_async` attribute, which prevented the Context from being initialized properly
* When the Context options parsing was refactored, a bug was introduced which caused a crash when the options field was empty
* Response type integers were calculated improperly for deferred Slash Command messages (not Message Component messages), leading to Discord rejecting the response
* `DiscordInteractions.run_handler` was not updated to use the new signature for `Context.create_handler_args`
* The custom ID length check would fail for Link buttons (which have no custom ID)

These have been patched in this PR.