### PR TITLE
Bugs found while testing Quart usage

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -22,6 +22,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install flake8 pytest pytest-cov pytest-asyncio quart sphinx
+        pip install aiohttp quart
         pip install -r requirements.txt
     - name: Lint with flake8
       run: |

--- a/docs/command.rst
+++ b/docs/command.rst
@@ -38,7 +38,7 @@ Advanced Usage
 If you use the ``options`` parameter of the
 :meth:`.DiscordInteractions.command` decorator to specify options manually,
 then it will override the options inferred from the function arguments
-and type annotation. You can use this to, for instance, route multiple 
+and type annotation. You can use this to, for instance, route multiple
 subcommands with different options to the same function. This isn't the
 recommended approach, but it is supported by the API.
 

--- a/docs/quart.rst
+++ b/docs/quart.rst
@@ -95,6 +95,7 @@ When creating command groups and subgroups, you will only get an
             print(type(ctx))
             await asyncio.sleep(1)
             await ctx.edit(f"Hello, {ctx.author.display_name}!")
+            await ctx.close()
 
         asyncio.create_task(do_followup())
         return Response(deferred=True)

--- a/docs/quart.rst
+++ b/docs/quart.rst
@@ -95,7 +95,6 @@ When creating command groups and subgroups, you will only get an
             print(type(ctx))
             await asyncio.sleep(1)
             await ctx.edit(f"Hello, {ctx.author.display_name}!")
-            await ctx.close()
 
         asyncio.create_task(do_followup())
         return Response(deferred=True)

--- a/docs/quart.rst
+++ b/docs/quart.rst
@@ -81,6 +81,25 @@ This class makes :meth:`.AsyncContext.edit`, :meth:`.AsyncContext.send`, and
         threading.Thread(target=do_followup).start()
         return Response(deferred=True)
 
+When creating command groups and subgroups, you will only get an
+:class:`.AsyncContext` if you provide the ``is_async=True`` flag.
+
+.. code-block:: python
+
+    toplevel = discord.command_group("toplevel", is_async=True)
+    secondlevel = toplevel.subgroup("secondlevel", is_async=True)
+
+    @secondlevel.command()
+    async def thirdlevel(ctx):
+        async def do_followup():
+            print(type(ctx))
+            await asyncio.sleep(1)
+            await ctx.edit(f"Hello, {ctx.author.display_name}!")
+            await ctx.close()
+
+        asyncio.create_task(do_followup())
+        return Response(deferred=True)
+
 Full API
 --------
 

--- a/examples/async_quart.py
+++ b/examples/async_quart.py
@@ -50,7 +50,6 @@ async def wait(ctx, seconds: int):
     async def do_followup():
         await asyncio.sleep(seconds)
         await ctx.edit("Done!")
-        await ctx.close()
 
     asyncio.create_task(do_followup())
     return Response(deferred=True)
@@ -77,7 +76,6 @@ def wait_partly_sync(ctx, seconds: int):
     async def do_followup():
         await asyncio.sleep(seconds)
         await ctx.edit("Done!")
-        await ctx.close()
 
     asyncio.create_task(do_followup())
     return Response(deferred=True)
@@ -93,7 +91,6 @@ async def thirdlevel(ctx):
         print(type(ctx))
         await asyncio.sleep(1)
         await ctx.edit(f"Hello, {ctx.author.display_name}!")
-        await ctx.close()
 
     asyncio.create_task(do_followup())
     return Response(deferred=True)

--- a/examples/async_quart.py
+++ b/examples/async_quart.py
@@ -43,6 +43,9 @@ def pong(ctx):
 # You can use followups with asyncio
 @discord.command()
 async def wait(ctx, seconds: int):
+    """
+    Waits for a certain number of seconds using the event loop (asyncio.sleep).
+    """
 
     async def do_followup():
         await asyncio.sleep(seconds)
@@ -56,12 +59,43 @@ async def wait(ctx, seconds: int):
 # Normal followups work as well
 @discord.command()
 def wait_sync(ctx, seconds: int):
+    "Waits for a certain number of seconds synchronously (using time.sleep)."
 
     def do_followup():
         time.sleep(seconds)
         ctx.edit("Done!")
 
     threading.Thread(target=do_followup).start()
+    return Response(deferred=True)
+
+
+# You can use the thread loop even from non-async commands
+@discord.command()
+def wait_partly_sync(ctx, seconds: int):
+    "A synchronous command that uses the event loop for waiting."
+
+    async def do_followup():
+        await asyncio.sleep(seconds)
+        await ctx.edit("Done!")
+        await ctx.close()
+
+    asyncio.create_task(do_followup())
+    return Response(deferred=True)
+
+
+# Async subcommands also work, and they can access context
+toplevel = discord.command_group("toplevel")
+secondlevel = toplevel.subgroup("secondlevel")
+
+@secondlevel.command()
+async def thirdlevel(ctx):
+    async def do_followup():
+        print(type(ctx))
+        await asyncio.sleep(1)
+        await ctx.edit(f"Hello, {ctx.author.display_name}!")
+        await ctx.close()
+
+    asyncio.create_task(do_followup())
     return Response(deferred=True)
 
 

--- a/examples/async_quart.py
+++ b/examples/async_quart.py
@@ -84,8 +84,8 @@ def wait_partly_sync(ctx, seconds: int):
 
 
 # Async subcommands also work, and they can access context
-toplevel = discord.command_group("toplevel")
-secondlevel = toplevel.subgroup("secondlevel")
+toplevel = discord.command_group("toplevel", is_async=True)
+secondlevel = toplevel.subgroup("secondlevel", is_async=True)
 
 @secondlevel.command()
 async def thirdlevel(ctx):

--- a/examples/async_quart.py
+++ b/examples/async_quart.py
@@ -50,6 +50,7 @@ async def wait(ctx, seconds: int):
     async def do_followup():
         await asyncio.sleep(seconds)
         await ctx.edit("Done!")
+        await ctx.close()
 
     asyncio.create_task(do_followup())
     return Response(deferred=True)
@@ -76,6 +77,7 @@ def wait_partly_sync(ctx, seconds: int):
     async def do_followup():
         await asyncio.sleep(seconds)
         await ctx.edit("Done!")
+        await ctx.close()
 
     asyncio.create_task(do_followup())
     return Response(deferred=True)
@@ -91,6 +93,7 @@ async def thirdlevel(ctx):
         print(type(ctx))
         await asyncio.sleep(1)
         await ctx.edit(f"Hello, {ctx.author.display_name}!")
+        await ctx.close()
 
     asyncio.create_task(do_followup())
     return Response(deferred=True)

--- a/flask_discord_interactions/command.py
+++ b/flask_discord_interactions/command.py
@@ -158,13 +158,6 @@ class SlashCommand:
 
         result = self.run(context, *args, **kwargs)
 
-        if self.is_async:
-            async def wrapper():
-                await context.close()
-                return await result
-
-            return Response.from_return_value(wrapper())
-
         return Response.from_return_value(result)
 
     def run(self, context, *args, **kwargs):

--- a/flask_discord_interactions/command.py
+++ b/flask_discord_interactions/command.py
@@ -195,6 +195,9 @@ class SlashCommandSubgroup(SlashCommand):
         The name of this subgroup, shown in the Discord client.
     description
         The description of this subgroup, shown in the Discord client.
+    is_async
+        Whether the subgroup should be considered async (if subcommands
+        get an :class:`AsyncContext` instead of a :class:`Context`.)
     """
 
     def __init__(self, name, description, is_async=False):
@@ -278,6 +281,9 @@ class SlashCommandGroup(SlashCommandSubgroup):
             The name of the subgroup, as displayed in the Discord client.
         description
             The description of the subgroup. Defaults to "No description".
+        is_async
+            Whether the subgroup should be considered async (if subcommands
+            get an :class:`AsyncContext` instead of a :class:`Context`.)
         """
 
         group = SlashCommandSubgroup(name, description, is_async)

--- a/flask_discord_interactions/command.py
+++ b/flask_discord_interactions/command.py
@@ -197,12 +197,12 @@ class SlashCommandSubgroup(SlashCommand):
         The description of this subgroup, shown in the Discord client.
     """
 
-    def __init__(self, name, description):
+    def __init__(self, name, description, is_async=False):
         self.name = name
         self.description = description
         self.subcommands = {}
 
-        self.is_async = False
+        self.is_async = is_async
 
     def command(self, name=None, description=None,
                 options=None, annotations=None):
@@ -267,7 +267,7 @@ class SlashCommandSubgroup(SlashCommand):
 
 
 class SlashCommandGroup(SlashCommandSubgroup):
-    def subgroup(self, name, description="No description"):
+    def subgroup(self, name, description="No description", is_async=False):
         """
         Create a new :class:`SlashCommandSubroup`
         (which can contain multiple subcommands)
@@ -280,6 +280,6 @@ class SlashCommandGroup(SlashCommandSubgroup):
             The description of the subgroup. Defaults to "No description".
         """
 
-        group = SlashCommandSubgroup(name, description)
+        group = SlashCommandSubgroup(name, description, is_async)
         self.subcommands[name] = group
         return group

--- a/flask_discord_interactions/command.py
+++ b/flask_discord_interactions/command.py
@@ -158,6 +158,13 @@ class SlashCommand:
 
         result = self.run(context, *args, **kwargs)
 
+        if self.is_async:
+            async def wrapper():
+                await context.close()
+                return await result
+
+            return Response.from_return_value(wrapper())
+
         return Response.from_return_value(result)
 
     def run(self, context, *args, **kwargs):

--- a/flask_discord_interactions/context.py
+++ b/flask_discord_interactions/context.py
@@ -505,6 +505,11 @@ class AsyncContext(Context):
     """
 
     def __post_init__(self):
+        if aiohttp == None:
+            raise ImportError(
+                "The aiohttp module is required for async usage of this "
+                "library")
+
         self.session = aiohttp.ClientSession(
             headers=self.auth_headers,
             raise_for_status=True,

--- a/flask_discord_interactions/discord.py
+++ b/flask_discord_interactions/discord.py
@@ -81,7 +81,7 @@ class DiscordInteractionsBlueprint:
 
         return decorator
 
-    def command_group(self, name, description="No description"):
+    def command_group(self, name, description="No description", is_async=False):
         """
         Create a new :class:`SlashCommandGroup`
         (which can contain multiple subcommands)
@@ -93,7 +93,7 @@ class DiscordInteractionsBlueprint:
         description
             The description of the command group.
         """
-        group = SlashCommandGroup(name, description)
+        group = SlashCommandGroup(name, description, is_async)
         self.discord_commands[name] = group
         return group
 

--- a/flask_discord_interactions/discord.py
+++ b/flask_discord_interactions/discord.py
@@ -92,7 +92,11 @@ class DiscordInteractionsBlueprint:
             The name of the command group, as displayed in the Discord client.
         description
             The description of the command group.
+        is_async
+            Whether the subgroup should be considered async (if subcommands
+            get an :class:`.AsyncContext` instead of a :class:`Context`.)
         """
+
         group = SlashCommandGroup(name, description, is_async)
         self.discord_commands[name] = group
         return group

--- a/flask_discord_interactions/tests/conftest.py
+++ b/flask_discord_interactions/tests/conftest.py
@@ -1,4 +1,5 @@
 import pytest
+import asyncio
 
 from flask import Flask
 

--- a/flask_discord_interactions/tests/test_full_quart.py
+++ b/flask_discord_interactions/tests/test_full_quart.py
@@ -7,17 +7,28 @@ from quart import Quart
 
 @pytest.fixture
 def mock_flask():
+    # Some ugly hackery required to get Quart's Flask patching to play nice
+    # with the actual Flask tests
+
     del sys.modules["flask"]
+    del sys.modules["flask_discord_interactions"]
+    del sys.modules["flask_discord_interactions.discord"]
+
     import quart.flask_patch
     yield None
+
     del sys.modules["flask"]
+
+    for name in list(sys.modules.keys()):
+        if name.startswith("flask."):
+            del sys.modules[name]
+
+    del sys.modules["flask_discord_interactions"]
+    del sys.modules["flask_discord_interactions.discord"]
 
 
 @pytest.mark.asyncio
 async def test_full_server(mock_flask):
-    del sys.modules["flask_discord_interactions"]
-    del sys.modules["flask_discord_interactions.discord"]
-
     from flask_discord_interactions import (DiscordInteractions,
                                         InteractionType, ResponseType)
 

--- a/flask_discord_interactions/tests/test_full_quart.py
+++ b/flask_discord_interactions/tests/test_full_quart.py
@@ -1,0 +1,58 @@
+import pytest
+import asyncio
+import sys
+
+from quart import Quart
+
+
+@pytest.fixture
+def mock_flask():
+    del sys.modules["flask"]
+    import quart.flask_patch
+    yield None
+    del sys.modules["flask"]
+
+
+@pytest.mark.asyncio
+async def test_full_server(mock_flask):
+    del sys.modules["flask_discord_interactions"]
+    del sys.modules["flask_discord_interactions.discord"]
+
+    from flask_discord_interactions import (DiscordInteractions,
+                                        InteractionType, ResponseType)
+
+    app = Quart("test_quart")
+    app.config["DONT_VALIDATE_SIGNATURE"] = True
+    app.config["DONT_REGISTER_WITH_DISCORD"] = True
+
+    discord = DiscordInteractions(app)
+
+    @discord.command()
+    async def wait(ctx):
+        await asyncio.sleep(0.01)
+        return "Hi!"
+
+    discord.set_route_async("/interactions")
+
+    client = app.test_client()
+
+    response = await client.post("/interactions", json={
+        "type": InteractionType.APPLICATION_COMMAND,
+        "id": 1,
+        "channel_id": "",
+        "guild_id": "",
+        "token": "",
+        "data": {
+            "id": 1,
+            "name": "wait"
+        }
+    })
+
+    assert response.status_code == 200
+
+    json = await response.get_json()
+
+    assert json["type"] == \
+        ResponseType.CHANNEL_MESSAGE_WITH_SOURCE
+
+    assert json["data"]["content"] == "Hi!"

--- a/flask_discord_interactions/tests/test_quart.py
+++ b/flask_discord_interactions/tests/test_quart.py
@@ -1,20 +1,13 @@
 import asyncio
 
 import pytest
+from quart import Quart
+
+from flask_discord_interactions import DiscordInteractions, Client
+
 
 @pytest.fixture()
 def quart_discord():
-    import sys
-    if "flask" in sys.modules:
-        del sys.modules["flask"]
-
-    from quart import Quart
-    import quart.flask_patch
-
-
-    from flask_discord_interactions import DiscordInteractions, Client
-
-
     app = Quart(__name__)
     discord = DiscordInteractions(app)
     return discord, Client(discord)


### PR DESCRIPTION
This PR includes bug fixes related to usage of Quart and asyncio.

* Subgroups would always pass a `Context`, not an `AsyncContext`, to subcommands. Now, the `is_async` flag controls this behavior
* A more helpful error message is displayed when `aiohttp` is not found and a user attempts to create an `AsyncContext`
* Unit testing for a Quart application using the Quart test client