### PR TITLE
Better document issues with mutli-worker deployment

### DIFF
--- a/docs/botsetup.rst
+++ b/docs/botsetup.rst
@@ -95,6 +95,10 @@ Deployment
 
 If you are using something like `Heroku <https://devcenter.heroku.com/articles/getting-started-with-python>`_ or `Dokku <http://dokku.viewdocs.io/dokku/>`_, your public URL should be visible when you deploy the app, something like ``https://serene-caverns-82714.herokuapp.com/``. If you are deploying directly to a cloud VPS with a public IP address, the steps are outlined in this `DigitalOcean <https://www.digitalocean.com/community/tutorials/how-to-serve-flask-applications-with-gunicorn-and-nginx-on-ubuntu-18-04>`_ tutorial (it should be similar for most providers). You could also deploy to a local machine and use a service like `No-IP <https://www.noip.com/support/knowledgebase/getting-started-with-no-ip-com/>`_ to expose it to the Internet.
 
+
+.. note::
+    If you'd like to deploy your bot in an environment with multiple workers, you might experience an issue where each worker tries to register your commands at the same time, causing you to be rate-limited. You should read the page on :ref:`workers` for information and advice relating to this issue.
+
 Tell Discord where to send interactions
 ---------------------------------------
 

--- a/docs/discord.rst
+++ b/docs/discord.rst
@@ -77,6 +77,9 @@ commands can take up to 1 hour.
 
     discord.update_slash_commands(guild_id=os.environ["TESTING_GUILD"])
 
+.. note::
+    If you'd like to deploy your bot in an environment with multiple workers, you might experience an issue where each worker tries to update your commands at the same time, causing you to be rate-limited. You should read the page on :ref:`workers` for information and advice relating to this issue.
+
 Now, like any other Flask app, all that's left to do is:
 
 .. code-block:: python

--- a/docs/tutorials.rst
+++ b/docs/tutorials.rst
@@ -6,3 +6,4 @@ Tutorials
 
     botsetup.rst
     debugging.rst
+    workers.rst

--- a/docs/workers.rst
+++ b/docs/workers.rst
@@ -46,8 +46,8 @@ multiple workers. Thus, this task left is up to you.**
 Here are some general approaches you can use to handle command registration for
 your app.
 
-1. Manual Command Update
-------------------------
+Approach 1: Manual Update
+-------------------------
 
 You can manually run ``discord.update_slash_commands`` before deploying your
 app. For convenience, you could put this behind a command line argument:
@@ -80,8 +80,8 @@ without doing command registration.
 This option is the most versatile, since it does not depend on any specific
 web server or hosting setup.
 
-2. Using Server Hooks
----------------------
+Approach 2: Server Hooks
+------------------------
 
 .. warning::
     *Note that if your application relies on parallelization beyond just one worker

--- a/docs/workers.rst
+++ b/docs/workers.rst
@@ -1,0 +1,143 @@
+.. _workers:
+
+Pitfalls with Multiple Workers
+==============================
+
+Does your bot work fine locally, but throw an error like this when you deploy
+it?
+
+.. code-block:: text
+
+    [2021-07-29 14:00:00 +0000] [12] [ERROR] Exception in worker process
+    Traceback (most recent call last):
+    File "/usr/local/lib/python3.9/site-packages/flask_discord_interactions/discord.py", line 273, in update_slash_commands
+        response.raise_for_status()
+    File "/usr/local/lib/python3.9/site-packages/requests/models.py", line 953, in raise_for_status
+        raise HTTPError(http_error_msg, response=self)
+    requests.exceptions.HTTPError: 429 Client Error: Too Many Requests for url: https://discord.com/api/v9/applications/[...]
+
+
+If you're deploying to an environment with multiple concurrent workers, you may
+run into a situation where each worker will independently attempt to register
+your application's slash commands with Discord. When this happens, there's a
+good chance you'll get rate-limited!
+
+Issue Reproduction
+------------------
+
+You can see this issue by running an example with ``gunicorn -w 4`` or similar.
+This will run four workers, each one will send a separate request to the
+Discord API, and some of them will get rate-limited and crash.
+
+Background
+----------
+
+Most of the examples for this library will call
+``discord.update_slash_commands`` when the Flask app initializes. This can be
+useful in a development environment: every time you restart your Flask app,
+it will ensure that any changes in your commands are sent to Discord.
+
+However, this becomes a problem if you want to serve your app with more than
+one worker.
+**Since each worker runs in an isolated environment, there isn't a reliable way
+for Flask-Discord-Interactions to "coordinate" command registration across
+multiple workers. Thus, this task left is up to you.**
+
+Here are some general approaches you can use to handle command registration for
+your app.
+
+1. Manual Command Update
+------------------------
+
+You can manually run ``discord.update_slash_commands`` before deploying your
+app. For convenience, you could put this behind a command line argument:
+
+.. code-block:: python
+
+
+    import sys
+    from flask import Flask
+    from flask_discord_interactions import DiscordInteractions
+
+    app = Flask(__name__)
+    discord = DiscordInteractions(app)
+
+    # ... configure your app and define your commands here ...
+
+    if "register" in sys.argv:
+        discord.update_slash_commands()
+        sys.exit()
+
+
+    if __name__ == '__main__':
+        app.run()
+
+You can run ``python3 app.py register`` (or similar) on your development
+machine once to register the slash commands with Discord, then
+``gunicorn app:app`` (or similar) on your production server to serve your app
+without doing command registration.
+
+This option is the most versatile, since it does not depend on any specific
+web server or hosting setup.
+
+2. Using Server Hooks
+---------------------
+
+.. warning::
+    *Note that if your application relies on parallelization beyond just one worker
+    pool, this approach probably won't work for you.* For instance, if you're
+    running multiple Heroku dynos / Docker containers / VM instances, each with its
+    own separate web server, then each container will still make its own API
+    requests, and you'll likely still see rate-limiting. **For this reason, for
+    more complex deployments, it is recommended that you use a manual
+    approach.**
+
+Some Python web servers provide "hooks" that allow you to execute code when
+certain server events happen. This usually includes when the server starts,
+when a new worker starts, and when the web server closes. These often must be
+defined in a separate configuration file. For this example, we will focus on
+Gunicorn.
+
+Gunicorn allows you to specify a configuration file with the ``-c [filename]``
+command-line argument. This file can define an ``on_starting`` function that
+will be executed exactly once when the server starts. This is where you can
+register your commands with Discord.
+
+You will need to make sure that your application module does not call
+``discord.update_slash_commands`` when it is invoked:
+
+.. code-block:: python
+
+    # filename: app.py
+    import sys
+    from flask import Flask
+    from flask_discord_interactions import DiscordInteractions
+
+    app = Flask(__name__)
+    discord = DiscordInteractions(app)
+
+    # ... configure your app and define your commands here ...
+    # but do NOT call `discord.update_slash_commands`
+
+    if __name__ == '__main__':
+        app.run()
+
+Then, you will need to create a configuration file for Gunicorn:
+
+.. code-block:: python
+
+    # filename: app_conf.py
+    from app import discord
+
+    def on_starting(server):
+        discord.update_slash_commands()
+
+(Note that your import structure may vary depending on your application
+structure.)
+
+Finally, specify your configuration file when you run Gunicorn:
+
+.. code-block:: bash
+
+    $ gunicorn -c app_conf.py app:app
+

--- a/examples/multiworker/automatic.py
+++ b/examples/multiworker/automatic.py
@@ -1,0 +1,40 @@
+"""
+This file is an example of how to use Gunicorn hooks to register commands to
+prevent the worker thread rate limit problem.
+
+Start the Gunicorn server with:
+    $ gunicorn \\
+        -w 4 \\
+        -c examples/multiworker/automatic_conf.py \\
+        examples.multiworker.automatic:app
+
+"""
+
+import os
+import sys
+
+from flask import Flask
+
+sys.path.insert(1, ".")
+
+from flask_discord_interactions import DiscordInteractions  # noqa: E402
+
+
+app = Flask(__name__)
+discord = DiscordInteractions(app)
+
+app.config["DISCORD_CLIENT_ID"] = os.environ["DISCORD_CLIENT_ID"]
+app.config["DISCORD_PUBLIC_KEY"] = os.environ["DISCORD_PUBLIC_KEY"]
+app.config["DISCORD_CLIENT_SECRET"] = os.environ["DISCORD_CLIENT_SECRET"]
+
+
+@discord.command()
+def multiworkerping(ctx):
+    "Respond with a friendly 'pong', served by one of many worker threads!"
+    return "Pong!"
+
+
+discord.set_route("/interactions")
+
+if __name__ == '__main__':
+    app.run()

--- a/examples/multiworker/automatic_conf.py
+++ b/examples/multiworker/automatic_conf.py
@@ -1,0 +1,10 @@
+import os
+import sys
+
+sys.path.insert(1, "examples/multiworker")
+
+from automatic import discord
+
+def on_starting(server):
+    print("registering commands!")
+    discord.update_slash_commands(guild_id=os.environ["TESTING_GUILD"])

--- a/examples/multiworker/manual.py
+++ b/examples/multiworker/manual.py
@@ -1,0 +1,55 @@
+"""
+This file is an example of how to manually register commands to prevent the
+worker thread rate limit problem.
+
+To run this example, first register the commands:
+    $ python3 examples/multiworker/manual.py register
+
+Then, start the Gunicorn server (or whichever server you are using):
+    $ gunicorn -w 4 examples.multiworker.manual:app
+
+"""
+
+import os
+import sys
+
+from flask import Flask
+
+sys.path.insert(1, ".")
+
+from flask_discord_interactions import DiscordInteractions  # noqa: E402
+
+
+app = Flask(__name__)
+discord = DiscordInteractions(app)
+
+app.config["DISCORD_CLIENT_ID"] = os.environ["DISCORD_CLIENT_ID"]
+app.config["DISCORD_PUBLIC_KEY"] = os.environ["DISCORD_PUBLIC_KEY"]
+app.config["DISCORD_CLIENT_SECRET"] = os.environ["DISCORD_CLIENT_SECRET"]
+
+
+@discord.command()
+def multiworkerping(ctx):
+    "Respond with a friendly 'pong', served by one of many worker threads!"
+    return "Pong!"
+
+
+discord.set_route("/interactions")
+
+
+# THIS WILL NOT WORK
+# it will attempt to register the commands at each worker thread
+# and will fail due to rate limiting
+# print("registering commands!")
+# discord.update_slash_commands(guild_id=os.environ["TESTING_GUILD"])
+
+
+# TRY THIS INSTEAD
+if "register" in sys.argv:
+    print("registering commands!")
+    discord.update_slash_commands(guild_id=os.environ["TESTING_GUILD"])
+    sys.exit()
+
+
+if __name__ == '__main__':
+    app.run()

--- a/flask_discord_interactions/discord.py
+++ b/flask_discord_interactions/discord.py
@@ -241,6 +241,11 @@ class DiscordInteractions(DiscordInteractionsBlueprint):
         Update the list of slash commands registered with Discord.
         This method will overwrite all existing slash commands.
 
+        Make sure you aren't calling this every time a new worker starts! You
+        will run into rate-limiting issues if multiple workers attempt to
+        register commands simultaneously. Read :ref:`workers` for more
+        info.
+
         Parameters
         ----------
         app


### PR DESCRIPTION
This PR adds a new page to the documentation discussing issues that can arise in a multi-worker environment when multiple workers attempt to register the same commands simultaneously. It lists some general solutions that can be applied to solve these issues.

Closes #35.