### PR TITLE
Implement Command Permissions

### DIFF
--- a/docs/permissions.rst
+++ b/docs/permissions.rst
@@ -1,0 +1,60 @@
+Permissions
+===========
+
+Discord allows defining permissions for each slash command in a specific guild
+or at the global level. Flask-Discord-Interactions provides a Permission class
+and two major ways of setting the permissions of a command.
+
+Permission class
+----------------
+
+The :class:`.Permission` class accepts either a role ID or a user ID.
+
+.. autoclass:: flask_discord_interactions.Permission
+    :members:
+
+
+Slash Command constructor
+-------------------------
+
+You can define permissions when defining a Slash Command. These will be
+registered immediately after your Slash Command is registered.
+
+You can set the ``default_permission``, then use the ``permissions`` parameter
+to specify any overwrites.
+
+.. code-block:: python
+
+    @discord.command(default_permission=False, permissions=[
+        Permission(role="786840072891662336")
+    ])
+    def command_with_perms(ctx):
+        "You need a certain role to access this command"
+
+        return "You have permissions!"
+
+Context object
+--------------
+
+You can also use the :meth:`.Context.overwrite_permissions` method to overwrite
+the permissions for a command. By default, this is the command currently
+invoked. However, you can specify a command name.
+
+.. code-block:: python
+
+    @discord.command(default_permission=False)
+    def locked_command(ctx):
+        "Secret command that has to be unlocked"
+
+        return "You have unlocked the secret command!"
+
+
+    @discord.command()
+    def unlock_command(ctx):
+        "Unlock the secret command"
+
+        ctx.overwrite_permissions(
+            [Permission(user=ctx.author.id)], "locked_command")
+
+        return "Unlocked!"
+

--- a/examples/permissions.py
+++ b/examples/permissions.py
@@ -19,7 +19,7 @@ discord.update_slash_commands()
 
 
 @discord.command(default_permission=False, permissions=[
-    Permission(user="386352037723635712")
+    Permission(role="786840072891662336")
 ])
 def command_with_perms(ctx):
     return "You have permissions!"

--- a/examples/permissions.py
+++ b/examples/permissions.py
@@ -22,8 +22,26 @@ discord.update_slash_commands()
     Permission(role="786840072891662336")
 ])
 def command_with_perms(ctx):
+    "You need a certain role to access this command"
+
     return "You have permissions!"
 
+
+@discord.command(default_permission=False)
+def locked_command(ctx):
+    "Secret command that has to be unlocked"
+
+    return "You have unlocked the secret command!"
+
+
+@discord.command()
+def unlock_command(ctx):
+    "Unlock the secret command"
+
+    ctx.overwrite_permissions(
+        [Permission(user=ctx.author.id)], "locked_command")
+
+    return "Unlocked!"
 
 
 discord.set_route("/interactions")

--- a/examples/permissions.py
+++ b/examples/permissions.py
@@ -1,0 +1,36 @@
+import os
+import sys
+
+from flask import Flask
+
+sys.path.insert(1, ".")
+
+from flask_discord_interactions import DiscordInteractions, Permission
+
+
+app = Flask(__name__)
+discord = DiscordInteractions(app)
+
+app.config["DISCORD_CLIENT_ID"] = os.environ["DISCORD_CLIENT_ID"]
+app.config["DISCORD_PUBLIC_KEY"] = os.environ["DISCORD_PUBLIC_KEY"]
+app.config["DISCORD_CLIENT_SECRET"] = os.environ["DISCORD_CLIENT_SECRET"]
+
+discord.update_slash_commands()
+
+
+@discord.command(default_permission=False, permissions=[
+    Permission(user="386352037723635712")
+])
+def command_with_perms(ctx):
+    return "You have permissions!"
+
+
+
+discord.set_route("/interactions")
+
+
+discord.update_slash_commands(guild_id=os.environ["TESTING_GUILD"])
+
+
+if __name__ == '__main__':
+    app.run()

--- a/flask_discord_interactions/__init__.py
+++ b/flask_discord_interactions/__init__.py
@@ -9,6 +9,7 @@ from flask_discord_interactions.context import (
     AsyncContext,
     CommandOptionType,
     ChannelType,
+    Permission,
     Member,
     User,
     Role,

--- a/flask_discord_interactions/command.py
+++ b/flask_discord_interactions/command.py
@@ -34,14 +34,18 @@ class SlashCommand:
         annotations. Do not use with ``options``. If omitted, and if
         ``options`` is not provided, option descriptions default to
         "No description".
+    default_permission
+        Whether the command is enabled by default. Default is True.
     """
 
-    def __init__(self, command, name, description, options, annotations):
+    def __init__(self, command, name, description, options, annotations,
+                 default_permission=True):
         self.command = command
         self.name = name
         self.description = description
         self.options = options
         self.annotations = annotations or {}
+        self.default_permission = default_permission
 
         if self.name is None:
             self.name = command.__name__

--- a/flask_discord_interactions/command.py
+++ b/flask_discord_interactions/command.py
@@ -192,6 +192,9 @@ class SlashCommand:
             "default_permission": self.default_permission
         }
 
+    def dump_permissions(self):
+        return [permission.dump() for permission in self.permissions]
+
 
 class SlashCommandSubgroup(SlashCommand):
     """

--- a/flask_discord_interactions/command.py
+++ b/flask_discord_interactions/command.py
@@ -36,16 +36,19 @@ class SlashCommand:
         "No description".
     default_permission
         Whether the command is enabled by default. Default is True.
+    permissions
+        List of permission overwrites.
     """
 
     def __init__(self, command, name, description, options, annotations,
-                 default_permission=True):
+                 default_permission=True, permissions=None):
         self.command = command
         self.name = name
         self.description = description
         self.options = options
         self.annotations = annotations or {}
         self.default_permission = default_permission
+        self.permissions = permissions or []
 
         if self.name is None:
             self.name = command.__name__

--- a/flask_discord_interactions/command.py
+++ b/flask_discord_interactions/command.py
@@ -188,7 +188,8 @@ class SlashCommand:
         return {
             "name": self.name,
             "description": self.description,
-            "options": self.options
+            "options": self.options,
+            "default_permission": self.default_permission
         }
 
 

--- a/flask_discord_interactions/context.py
+++ b/flask_discord_interactions/context.py
@@ -36,6 +36,23 @@ class ChannelType:
     GUILD_STORE = 6
 
 
+class Permission:
+    def __init__(self, role=None, user=None, allow=True):
+        if bool(role) == bool(user):
+            raise ValueError("specify only one of role or user")
+
+        self.type = 1 if role else 2
+        self.id = role or user
+        self.permission = allow
+
+    def dump(self):
+        return {
+            "type": self.type,
+            "id": self.id,
+            "permission": self.permission
+        }
+
+
 class ContextObject:
     @classmethod
     def from_dict(cls, data):

--- a/flask_discord_interactions/context.py
+++ b/flask_discord_interactions/context.py
@@ -37,6 +37,19 @@ class ChannelType:
 
 
 class Permission:
+    """
+    An object representing a single permission overwrite.
+
+    ``Permission(role='1234')`` allows users with role ID 1234 to use the
+    command
+
+    ``Permission(user='5678')`` allows user ID 5678 to use the command
+
+    ``Permission(role='9012', allow=False)`` denies users with role ID 9012
+    from using the command
+    """
+
+
     def __init__(self, role=None, user=None, allow=True):
         if bool(role) == bool(user):
             raise ValueError("specify only one of role or user")

--- a/flask_discord_interactions/discord.py
+++ b/flask_discord_interactions/discord.py
@@ -30,8 +30,9 @@ class DiscordInteractionsBlueprint:
         self.discord_commands = {}
         self.custom_id_handlers = {}
 
-    def add_slash_command(self, command, name=None,
-                          description=None, options=None, annotations=None):
+    def add_slash_command(self, command, name=None, description=None,
+                          options=None, annotations=None,
+                          default_permission=None, permissions=None):
         """
         Create and add a new :class:`SlashCommand`.
 
@@ -49,13 +50,18 @@ class DiscordInteractionsBlueprint:
         annotations
             If ``options`` is not provided, descriptions for each of the
             options defined in the function's keyword arguments.
+        default_permission
+            Whether the command is enabled by default. Default is True.
+        permissions
+            List of permission overwrites.
         """
         slash_command = SlashCommand(
-            command, name, description, options, annotations)
+            command, name, description, options, annotations,
+            default_permission, permissions)
         self.discord_commands[slash_command.name] = slash_command
 
-    def command(self, name=None, description=None,
-                options=None, annotations=None):
+    def command(self, name=None, description=None, options=None,
+                annotations=None, default_permission=None, permissions=None):
         """
         Decorator to create a new :class:`SlashCommand`.
 
@@ -71,12 +77,17 @@ class DiscordInteractionsBlueprint:
         annotations
             If ``options`` is not provided, descriptions for each of the
             options defined in the function's keyword arguments.
+        default_permission
+            Whether the command is enabled by default. Default is True.
+        permissions
+            List of permission overwrites.
         """
 
         def decorator(func):
             nonlocal name, description, options
             self.add_slash_command(
-                func, name, description, options, annotations)
+                func, name, description, options, annotations,
+                default_permission, permissions)
             return func
 
         return decorator

--- a/flask_discord_interactions/tests/test_subcommand.py
+++ b/flask_discord_interactions/tests/test_subcommand.py
@@ -87,16 +87,3 @@ def test_context_with_subcommand(discord, client):
 
     with client.context(context):
         assert client.run("group", "subcommand").content == "Bob"
-
-def test_followup_with_subcommand(discord, client):
-    group = discord.command_group("group")
-
-    @group.command()
-    def subcommand(ctx):
-        return ctx.base_url
-
-    context = Context(base_url="https://discord.com/")
-
-    with client.context(context):
-        assert client.run("group", "subcommand").content == \
-            "https://discord.com/"


### PR DESCRIPTION
This PR allows users to use Command Permissions to restrict who can execute a Slash Command.

Closes #21.

This adds two ways of interacting with Permissions: the `SlashCommand(permissions=...)` argument and the `Context.overwrite_permissions` method. It also documents these methods and provides an example.