### PR TITLE
discord.command_group() does not work (#43)

### DIFF
--- a/flask_discord_interactions/command.py
+++ b/flask_discord_interactions/command.py
@@ -218,6 +218,9 @@ class SlashCommandSubgroup(SlashCommand):
         self.description = description
         self.subcommands = {}
 
+        self.default_permission = None
+        self.permissions = []
+
         self.is_async = is_async
 
     def command(self, name=None, description=None,

--- a/flask_discord_interactions/tests/test_register.py
+++ b/flask_discord_interactions/tests/test_register.py
@@ -1,0 +1,62 @@
+from flask import Flask
+
+from flask_discord_interactions import DiscordInteractions, ResponseType, InteractionType
+
+def test_register_command():
+    app = Flask(__name__)
+    app.config["DONT_VALIDATE_SIGNATURE"] = True
+    app.config["DONT_REGISTER_WITH_DISCORD"] = True
+
+    discord = DiscordInteractions(app)
+
+    @discord.command()
+    def ping(ctx):
+        return "pong"
+
+    discord.update_slash_commands()
+
+
+def test_register_subcommand():
+    app = Flask(__name__)
+    app.config["DONT_VALIDATE_SIGNATURE"] = True
+    app.config["DONT_REGISTER_WITH_DISCORD"] = True
+
+    discord = DiscordInteractions(app)
+
+    group = discord.command_group("group")
+
+    @group.command()
+    def subcommand(ctx):
+        return "pong"
+
+    discord.update_slash_commands()
+
+
+def test_register_options():
+    app = Flask(__name__)
+    app.config["DONT_VALIDATE_SIGNATURE"] = True
+    app.config["DONT_REGISTER_WITH_DISCORD"] = True
+
+    discord = DiscordInteractions(app)
+
+    @discord.command()
+    def ping(ctx, option1: str, option2: float, option3: str = ""):
+        return f"pong"
+
+    discord.update_slash_commands()
+
+
+def test_register_subcommand_options():
+    app = Flask(__name__)
+    app.config["DONT_VALIDATE_SIGNATURE"] = True
+    app.config["DONT_REGISTER_WITH_DISCORD"] = True
+
+    discord = DiscordInteractions(app)
+
+    group = discord.command_group("group")
+
+    @group.command()
+    def subcommand(ctx, option1: str, option2: float, option3: str = ""):
+        return "pong"
+
+    discord.update_slash_commands()


### PR DESCRIPTION
Hotfix for a bug that prevented SlashCommandGroups from being registered with Discord. SlashCommandGroups now have permissions attributes so that they can be registered just like a normal command. These attributes are empty as group-level permissions are not supported.