### PR TITLE
Add support for user and message command types

### DIFF
--- a/docs/command.rst
+++ b/docs/command.rst
@@ -32,6 +32,40 @@ The function must return either a string or a
 more information about what kind of responses are valid, see
 :ref:`response-page`.
 
+User Commands
+-------------
+
+User Commands are created using the :meth:`.DiscordInteractions.command`
+decorator. The `type` needs to be specified using the 
+:class:`.ApplicationCommandType.USER`.
+
+Here is a basic command:
+
+.. code-block:: python
+
+    @discord.command(type=ApplicationCommandType.USER)
+    def userCmd(ctx):
+        return "something"
+
+Options and Description cannot be provided.
+
+Message Commands
+-------------
+
+User Commands are created using the :meth:`.DiscordInteractions.command`
+decorator. The `type` needs to be specified using the 
+:class:`.ApplicationCommandType.MESSAGE`.
+
+Here is a basic command:
+
+.. code-block:: python
+
+    @discord.command(type=ApplicationCommandType.MESSAGE)
+    def msgCmd(ctx):
+        return "something"
+
+Options and Description cannot be provided.
+
 Advanced Usage
 ^^^^^^^^^^^^^^
 

--- a/docs/command.rst
+++ b/docs/command.rst
@@ -36,7 +36,7 @@ User Commands
 -------------
 
 User Commands are created using the :meth:`.DiscordInteractions.command`
-decorator. The `type` needs to be specified using the 
+decorator. The ``type`` needs to be specified using the
 :class:`.ApplicationCommandType.USER`.
 
 Here is a basic command:
@@ -53,7 +53,7 @@ Message Commands
 -------------
 
 User Commands are created using the :meth:`.DiscordInteractions.command`
-decorator. The `type` needs to be specified using the 
+decorator. The ``type`` needs to be specified using the
 :class:`.ApplicationCommandType.MESSAGE`.
 
 Here is a basic command:

--- a/examples/messagecommands.py
+++ b/examples/messagecommands.py
@@ -29,8 +29,8 @@ discord.update_slash_commands()
 
 # Simple command to change a message
 @discord.command(name="Make it bold", type=ApplicationCommandType.MESSAGE)
-def boldMessage(ctx):
-    return f"**{json.loads(json.dumps(next(iter(next(iter(ctx.resolved.values())).values()))))['content']}**"
+def boldMessage(ctx, message):
+    return f"**{message.content}**"
 
 
 # This is the URL that your app will listen for Discord Interactions on

--- a/examples/messagecommands.py
+++ b/examples/messagecommands.py
@@ -1,0 +1,49 @@
+import os
+import sys
+
+import json
+
+from flask import Flask
+
+# This is just here for the sake of examples testing
+# to make sure that the imports work
+# (you don't actually need it in your code)
+sys.path.insert(1, ".")
+
+from flask_discord_interactions import DiscordInteractions  # noqa: E402
+from flask_discord_interactions.context import ApplicationCommandType
+
+
+app = Flask(__name__)
+discord = DiscordInteractions(app)
+
+# Find these in your Discord Developer Portal, store them as environment vars
+app.config["DISCORD_CLIENT_ID"] = os.environ["DISCORD_CLIENT_ID"]
+app.config["DISCORD_PUBLIC_KEY"] = os.environ["DISCORD_PUBLIC_KEY"]
+app.config["DISCORD_CLIENT_SECRET"] = os.environ["DISCORD_CLIENT_SECRET"]
+
+
+# Clear any existing global slash commands
+discord.update_slash_commands()
+
+
+# Simple command to change a message
+@discord.command(name="Make it bold", type=ApplicationCommandType.MESSAGE)
+def boldMessage(ctx):
+    return f"**{json.loads(json.dumps(next(iter(next(iter(ctx.resolved.values())).values()))))['content']}**"
+
+
+# This is the URL that your app will listen for Discord Interactions on
+# Put this into the developer portal
+discord.set_route("/interactions")
+
+
+# Register slash commands with this
+# (omit guild_id parameter to register global commands,
+# but note that these can take up to 1 hour to be registered)
+# This also removes old/unused slash commands
+discord.update_slash_commands(guild_id=os.environ["TESTING_GUILD"])
+
+
+if __name__ == '__main__':
+    app.run()

--- a/examples/usercommands.py
+++ b/examples/usercommands.py
@@ -1,0 +1,47 @@
+import os
+import sys
+
+from flask import Flask
+
+# This is just here for the sake of examples testing
+# to make sure that the imports work
+# (you don't actually need it in your code)
+sys.path.insert(1, ".")
+
+from flask_discord_interactions import DiscordInteractions  # noqa: E402
+from flask_discord_interactions.context import ApplicationCommandType
+
+
+app = Flask(__name__)
+discord = DiscordInteractions(app)
+
+# Find these in your Discord Developer Portal, store them as environment vars
+app.config["DISCORD_CLIENT_ID"] = os.environ["DISCORD_CLIENT_ID"]
+app.config["DISCORD_PUBLIC_KEY"] = os.environ["DISCORD_PUBLIC_KEY"]
+app.config["DISCORD_CLIENT_SECRET"] = os.environ["DISCORD_CLIENT_SECRET"]
+
+
+# Clear any existing global slash commands
+discord.update_slash_commands()
+
+
+# Simple command to mention a friend
+@discord.command(name="High Five", type=ApplicationCommandType.USER)
+def highFive(ctx):
+    return f"<@{ctx.author.id}> wants to say hello to <@{next(iter(ctx.members))}>"
+
+
+# This is the URL that your app will listen for Discord Interactions on
+# Put this into the developer portal
+discord.set_route("/interactions")
+
+
+# Register slash commands with this
+# (omit guild_id parameter to register global commands,
+# but note that these can take up to 1 hour to be registered)
+# This also removes old/unused slash commands
+discord.update_slash_commands(guild_id=os.environ["TESTING_GUILD"])
+
+
+if __name__ == '__main__':
+    app.run()

--- a/examples/usercommands.py
+++ b/examples/usercommands.py
@@ -26,9 +26,11 @@ discord.update_slash_commands()
 
 
 # Simple command to mention a friend
+# The target user is passed as an argument
 @discord.command(name="High Five", type=ApplicationCommandType.USER)
-def highFive(ctx):
-    return f"<@{ctx.author.id}> wants to say hello to <@{next(iter(ctx.members))}>"
+def highFive(ctx, target):
+    # we can also pull from ctx.target.id
+    return f"<@{ctx.author.id}> wants to say hello to <@{target.id}>"
 
 
 # This is the URL that your app will listen for Discord Interactions on

--- a/flask_discord_interactions/__init__.py
+++ b/flask_discord_interactions/__init__.py
@@ -7,6 +7,7 @@ from flask_discord_interactions.command import (
 from flask_discord_interactions.context import (
     Context,
     AsyncContext,
+    ApplicationCommandType,
     CommandOptionType,
     ChannelType,
     Permission,

--- a/flask_discord_interactions/context.py
+++ b/flask_discord_interactions/context.py
@@ -10,6 +10,13 @@ import requests
 from flask_discord_interactions.response import Response
 
 
+class ApplicationCommandType:
+    "Represents the different application command types integers."
+    CHAT_INPUT = 1
+    USER = 2
+    MESSAGE = 3
+
+
 class CommandOptionType:
     "Represents the different option type integers."
     SUB_COMMAND = 1

--- a/flask_discord_interactions/discord.py
+++ b/flask_discord_interactions/discord.py
@@ -17,7 +17,7 @@ except ImportError:
     aiohttp = None
 
 from flask_discord_interactions.command import SlashCommand, SlashCommandGroup
-from flask_discord_interactions.context import Context
+from flask_discord_interactions.context import Context, ApplicationCommandType
 from flask_discord_interactions.response import Response, ResponseType
 
 
@@ -38,7 +38,8 @@ class DiscordInteractionsBlueprint:
         self.custom_id_handlers = {}
 
     def add_slash_command(self, command, name=None, description=None,
-                          options=None, annotations=None,
+                          options=None, annotations=None, 
+                          type=ApplicationCommandType.CHAT_INPUT,
                           default_permission=None, permissions=None):
         """
         Create and add a new :class:`SlashCommand`.
@@ -57,6 +58,8 @@ class DiscordInteractionsBlueprint:
         annotations
             If ``options`` is not provided, descriptions for each of the
             options defined in the function's keyword arguments.
+        type
+            The ``ApplicationCommandType`` of the command.
         default_permission
             Whether the command is enabled by default. Default is True.
         permissions
@@ -64,11 +67,11 @@ class DiscordInteractionsBlueprint:
         """
         slash_command = SlashCommand(
             command, name, description, options, annotations,
-            default_permission, permissions)
+            type, default_permission, permissions)
         self.discord_commands[slash_command.name] = slash_command
 
-    def command(self, name=None, description=None, options=None,
-                annotations=None, default_permission=None, permissions=None):
+    def command(self, name=None, description=None, options=None, annotations=None, 
+                type=ApplicationCommandType.CHAT_INPUT, default_permission=None, permissions=None):
         """
         Decorator to create a new :class:`SlashCommand`.
 
@@ -84,6 +87,8 @@ class DiscordInteractionsBlueprint:
         annotations
             If ``options`` is not provided, descriptions for each of the
             options defined in the function's keyword arguments.
+        type
+            The ``ApplicationCommandType`` of the command.
         default_permission
             Whether the command is enabled by default. Default is True.
         permissions
@@ -91,10 +96,10 @@ class DiscordInteractionsBlueprint:
         """
 
         def decorator(func):
-            nonlocal name, description, options
+            nonlocal name, description, type, options
             self.add_slash_command(
                 func, name, description, options, annotations,
-                default_permission, permissions)
+                type, default_permission, permissions)
             return func
 
         return decorator

--- a/flask_discord_interactions/response.py
+++ b/flask_discord_interactions/response.py
@@ -141,6 +141,17 @@ class Response:
         else:
             return cls(str(result))
 
+    @classmethod
+    def from_message_command(cls, data):
+        """
+        Construct a Response object from an incoming Message Command
+        Interaction.
+        """
+
+        return cls(
+            content=data["content"],
+        )
+
     def dump(self):
         """
         Return this ``Response`` as a dict to be sent in response to an

--- a/flask_discord_interactions/tests/test_command.py
+++ b/flask_discord_interactions/tests/test_command.py
@@ -1,3 +1,5 @@
+from flask_discord_interactions.tests.conftest import client
+from flask_discord_interactions.context import ApplicationCommandType
 import pytest
 
 
@@ -27,3 +29,31 @@ def test_invalid_character(discord):
         @discord.command(name="invalid&character")
         def invalid_character(ctx):
             return "this shouldn't work..."
+
+def test_type_user_valid(discord, client):
+    @discord.command(name="testuser", type=ApplicationCommandType.USER)
+    def fn(ctx):
+        return "hi user"
+    
+    assert client.run("testuser").content == "hi user"
+
+def test_type_message_valid(discord, client):
+    @discord.command(name="testmessage", type=ApplicationCommandType.MESSAGE)
+    def fn(ctx):
+        return "message"
+    
+    assert client.run("testmessage").content == "message"
+
+def test_type_user_valid_uppercase(discord, client):
+    @discord.command(name="TEST USER", type=ApplicationCommandType.USER)
+    def fn(ctx):
+        return "hi user"
+    
+    assert client.run("TEST USER").content == "hi user"
+
+def test_type_message_valid_uppercase(discord, client):
+    @discord.command(name="TEST MSG", type=ApplicationCommandType.MESSAGE)
+    def fn(ctx):
+        return "message"
+    
+    assert client.run("TEST MSG").content == "message"

--- a/flask_discord_interactions/tests/test_register.py
+++ b/flask_discord_interactions/tests/test_register.py
@@ -1,6 +1,7 @@
 from flask import Flask
 
 from flask_discord_interactions import DiscordInteractions, ResponseType, InteractionType
+from flask_discord_interactions.context import ApplicationCommandType
 
 def test_register_command():
     app = Flask(__name__)
@@ -10,6 +11,50 @@ def test_register_command():
     discord = DiscordInteractions(app)
 
     @discord.command()
+    def ping(ctx):
+        return "pong"
+
+    discord.update_slash_commands()
+
+
+def test_register_user_command():
+    app = Flask(__name__)
+    app.config["DONT_VALIDATE_SIGNATURE"] = True
+    app.config["DONT_REGISTER_WITH_DISCORD"] = True
+
+    discord = DiscordInteractions(app)
+
+    @discord.command(type=ApplicationCommandType.USER)
+    def ping(ctx):
+        return "pong"
+    
+    @discord.command(type=ApplicationCommandType.USER)
+    def PING(ctx):
+        return "pong"
+    
+    @discord.command(name="user test", type=ApplicationCommandType.USER)
+    def ping(ctx):
+        return "pong"
+
+    discord.update_slash_commands()
+
+
+def test_register_message_command():
+    app = Flask(__name__)
+    app.config["DONT_VALIDATE_SIGNATURE"] = True
+    app.config["DONT_REGISTER_WITH_DISCORD"] = True
+
+    discord = DiscordInteractions(app)
+
+    @discord.command(type=ApplicationCommandType.MESSAGE)
+    def ping(ctx):
+        return "pong"
+    
+    @discord.command(type=ApplicationCommandType.MESSAGE)
+    def PING(ctx):
+        return "pong"
+    
+    @discord.command(name="user test", type=ApplicationCommandType.MESSAGE)
     def ping(ctx):
         return "pong"
 


### PR DESCRIPTION
This PR add support for user command and message command (Closes #50).

I tried to reuse a lot of components without adding classes, but only the support of the type to choose it with the decorator. I added tests to respect conditions from the documentation.

I added some unit tests and some documentations. Maybe this can be improved, just tell me.

It will be a good idea to rename SlashCommand class to `ApplicationCommand` since a `SlashCommand` is an `ApplicationCommand` with `CHAT_INPUT` type. I didn't make theses changes since this will rename a lot of components and deprecates some others.

I hope this will be okay for you, feel free to give me feedback, I can improve what you want.