### PR TITLE
Document usage of `set_route_async` with Quart

### DIFF
--- a/docs/discord.rst
+++ b/docs/discord.rst
@@ -61,6 +61,13 @@ from the same Flask app.
 
     discord.set_route("/interactions")
 
+.. note::
+    If you want to use Flask-Discord-Interactions with Quart instead,
+    you should use :meth:`.DiscordInteractions.set_route_async`. This
+    functions similarly, but it registers the route handler
+    as an async function, allowing it to ``await`` your function handlers.
+    For details, see :ref:`quart-page`.
+
 Finally, you need to register the commands with Discord.
 :meth:`.DiscordInteractions.update_commands` will automatically get
 the list of currently registered commands, delete any that are no longer

--- a/docs/quart.rst
+++ b/docs/quart.rst
@@ -1,3 +1,5 @@
+.. _quart-page:
+
 Using Asyncio with Quart
 ========================
 

--- a/docs/quart.rst
+++ b/docs/quart.rst
@@ -16,6 +16,9 @@ to have a similar API to Flask, but using :py:mod:`asyncio`.
 
     app.run()
 
+Monkey Patching
+---------------
+
 Flask-Discord-Interactions supports using Quart. This can provide a more
 familiar development experience to those used to ``discord.py``'s
 async commands.
@@ -52,6 +55,25 @@ commands, and to allow awaiting when handling followup messages.
     @discord.command()
     def pong(ctx):
         return "Ping!"
+
+Use an Async Route Handler
+--------------------------
+
+If you want to use async commands in Flask-Discord-Interactions, then the
+library needs to register an asynchronous handler for the interactions
+endpoint. This is what allows Flask-Discord-Interactions to ``await``
+your function handler.
+
+If you are using Flask-Discord-Interactions with Quart, you need to call
+:meth:`.DiscordInteractions.set_route_async` instead of
+:meth:`.DiscordInteractions.set_route`.
+
+.. code-block:: python
+
+    discord.set_route_async("/interactions")
+
+Context in Async Commands
+-------------------------
 
 A special :class:`.AsyncContext` class is exposed to asynchronous commands.
 This class makes :meth:`.AsyncContext.edit`, :meth:`.AsyncContext.send`, and

--- a/flask_discord_interactions/discord.py
+++ b/flask_discord_interactions/discord.py
@@ -491,6 +491,9 @@ class DiscordInteractions(DiscordInteractionsBlueprint):
         Add a route handler to the Flask app that handles incoming
         interaction data.
 
+        If you are using Quart, you should use
+        :meth:`.DiscordInteractions.set_route_async` instead.
+
         Parameters
         ----------
         route


### PR DESCRIPTION
This PR improves the documentation to specify that Quart users must call `DiscordInteractions.set_route_async` instead of `set_route`.

Closes #59.