### PR TITLE
Command Group Permissions

### DIFF
--- a/docs/permissions.rst
+++ b/docs/permissions.rst
@@ -33,6 +33,27 @@ to specify any overwrites.
 
         return "You have permissions!"
 
+Subcommands and Command Groups
+------------------------------
+
+Discord only supports attaching permissions overwrites to top-level commands.
+Thus, there are no ``default_permission`` or ``permissions`` parameters for the
+:meth:`.SlashCommandGroup.command` decorator. However, you can still set
+permissions for an entire tree of subcommands using the
+:meth:`.DiscordInteractions.command_group` function.
+
+.. code-block:: python
+
+    group = discord.command_group("group", default_permission=False, permissions=[
+        Permission(role="786840072891662336")
+    ])
+
+    @group.command()
+    def locked_subcommand(ctx):
+        "Locked subcommand"
+
+        return "You have unlocked the secret subcommand!"
+
 Context object
 --------------
 

--- a/examples/permissions.py
+++ b/examples/permissions.py
@@ -44,6 +44,19 @@ def unlock_command(ctx):
     return "Unlocked!"
 
 
+# Command groups can have permissions at the top level
+
+group = discord.command_group("group", default_permission=False, permissions=[
+    Permission(role="786840072891662336")
+])
+
+@group.command()
+def locked_subcommand(ctx):
+    "Locked subcommand"
+
+    return "You have unlocked the secret subcommand!"
+
+
 discord.set_route("/interactions")
 
 

--- a/examples/permissions.py
+++ b/examples/permissions.py
@@ -56,6 +56,14 @@ def locked_subcommand(ctx):
 
     return "You have unlocked the secret subcommand!"
 
+@group.command()
+def lock_me_out(ctx):
+    "Lock me out of this group"
+
+    ctx.overwrite_permissions([Permission(user=ctx.author.id, allow=False)])
+
+    return "Locked!"
+
 
 discord.set_route("/interactions")
 

--- a/flask_discord_interactions/command.py
+++ b/flask_discord_interactions/command.py
@@ -302,6 +302,37 @@ class SlashCommandSubgroup(Command):
 
 
 class SlashCommandGroup(SlashCommandSubgroup):
+    """
+    Represents a Subgroup of slash commands.
+
+    Attributes
+    ----------
+    name
+        The name of this subgroup, shown in the Discord client.
+    description
+        The description of this subgroup, shown in the Discord client.
+    is_async
+        Whether the subgroup should be considered async (if subcommands
+        get an :class:`AsyncContext` instead of a :class:`Context`.)
+    default_permission
+        Whether the subgroup is enabled by default. Default is True.
+    permissions
+        List of permission overwrites. These apply to all subcommands of this
+        group.
+    """
+
+    def __init__(self, name, description, is_async=False,
+                 default_permission=True, permissions=None):
+        self.name = name
+        self.description = description
+        self.subcommands = {}
+        self.type = ApplicationCommandType.CHAT_INPUT
+
+        self.default_permission = default_permission
+        self.permissions = permissions or []
+
+        self.is_async = is_async
+
     def subgroup(self, name, description="No description", is_async=False):
         """
         Create a new :class:`SlashCommandSubroup`

--- a/flask_discord_interactions/discord.py
+++ b/flask_discord_interactions/discord.py
@@ -135,6 +135,10 @@ class DiscordInteractionsBlueprint:
         is_async
             Whether the subgroup should be considered async (if subcommands
             get an :class:`.AsyncContext` instead of a :class:`Context`.)
+        default_permission
+            Whether the command group is enabled by default.
+        permissions
+            List of permission overwrites. These apply to the entire group.
         """
 
         group = SlashCommandGroup(

--- a/flask_discord_interactions/discord.py
+++ b/flask_discord_interactions/discord.py
@@ -120,7 +120,8 @@ class DiscordInteractionsBlueprint:
 
         return decorator
 
-    def command_group(self, name, description="No description", is_async=False):
+    def command_group(self, name, description="No description", is_async=False,
+                      default_permission=None, permissions=None):
         """
         Create a new :class:`SlashCommandGroup`
         (which can contain multiple subcommands)
@@ -136,7 +137,8 @@ class DiscordInteractionsBlueprint:
             get an :class:`.AsyncContext` instead of a :class:`Context`.)
         """
 
-        group = SlashCommandGroup(name, description, is_async)
+        group = SlashCommandGroup(
+            name, description, is_async, default_permission, permissions)
         self.discord_commands[name] = group
         return group
 


### PR DESCRIPTION
**Checklist**
This pull request...

- [ ] Fixes a bug
- [X] Adds new functionality
- [X] Updates documentation and/or examples
- [ ] Adds tests
- [ ] Is a **breaking** change -- existing code written for this library may need to be rewritten to work after these changes.

**Description**
Adds `default_permission` and `permissions` arguments to `DiscordInteractions.command_group()` and `SlashCommandGroup()`. This allows users to set permissions for command groups which will apply to all of the subcommands inside.

**Linked Issue**
Resolves #65.

