### PR TITLE
allow dump_embed() and dump_components() to return empty lists

### DIFF
--- a/flask_discord_interactions/models/message.py
+++ b/flask_discord_interactions/models/message.py
@@ -130,11 +130,11 @@ class Message(LoadableDataclass):
 
     def dump_embeds(self):
         "Returns the embeds of this Message as a list of dicts."
-        return [embed.dump() for embed in self.embeds] if self.embeds else None
+        return [embed.dump() for embed in self.embeds] if self.embeds is not None else None
 
     def dump_components(self):
         "Returns the message components as a list of dicts."
-        return [c.dump() for c in self.components] if self.components else None
+        return [c.dump() for c in self.components] if self.components is not None else None
 
     @classmethod
     def from_return_value(cls, result):


### PR DESCRIPTION
**Checklist**
This pull request...

- [x] Fixes a bug
- [ ] Adds new functionality
- [ ] Updates documentation and/or examples
- [ ] Adds tests
- [ ] Is a **breaking** change -- existing code written for this library may need to be rewritten to work after these changes.

**Description**
This rather small change allows `Message.dump_components()` and `Message.dump_embeds()` to return empty lists.

**Reasons for this change**
This change affects the editing of messages. There are some cases where you want to entirely remove components or embeds in a message and this is done via sending a message with an empty list at the according field to the discord api. Before this fix, the lib replaced all empty lists with `None` while dumping the message. This is fixed now.