### PR TITLE
Update Message Object examples for Ephemeral Embeds

### DIFF
--- a/docs/message.rst
+++ b/docs/message.rst
@@ -49,7 +49,7 @@ response ephemeral:
         return Message(
             "Ephemeral messages are only sent to the user who ran the command, "
             "and they go away after a short while.\n\n"
-            "Note that they cannot include embeds or files, "
+            "Note that they cannot include files, "
             "but Markdown is *perfectly fine.*",
             ephemeral=True
         )

--- a/examples/message_object.py
+++ b/examples/message_object.py
@@ -80,8 +80,32 @@ def ephemeral(ctx):
     return Message(
         "Ephemeral messages are only sent to the user who ran the command, "
         "and they go away after a short while.\n\n"
-        "Note that they cannot include embeds or files, "
+        "Note that they cannot include files, "
         "but Markdown is *perfectly fine.*",
+        ephemeral=True
+    )
+
+
+@discord.command()
+def ephemeral_embed(ctx):
+    "Ephemeral Message with an Embed"
+
+    return Message(
+        embed=Embed(
+            title="Embeds!",
+            description="Messages with Embeds can also be Ephemeral.",
+            fields=[
+                embed.Field(
+                    name="Can they use markdown?",
+                    value="**Yes!** [link](https://google.com/)"
+                ),
+                embed.Field(
+                    name="Where do I learn about how to format this object?",
+                    value=("[Try this visualizer!]"
+                           "(https://leovoel.github.io/embed-visualizer/)")
+                )
+            ]
+        ),
         ephemeral=True
     )
 


### PR DESCRIPTION
As of https://github.com/Breq16/flask-discord-interactions/commit/1c7324499bd90e5fd6968c1a56de3c72aae4631d, Message objects can be Ephemeral and contain an Embed, but the examples hadn't been updated to reflect that.