### PR TITLE
Improve documentation for files

### DIFF
--- a/docs/command.rst
+++ b/docs/command.rst
@@ -50,7 +50,7 @@ Here is a basic command:
 Options and Description cannot be provided.
 
 Message Commands
--------------
+----------------
 
 User Commands are created using the :meth:`.DiscordInteractions.command`
 decorator. The ``type`` needs to be specified using the

--- a/docs/components.rst
+++ b/docs/components.rst
@@ -196,7 +196,7 @@ a custom ID string. Instead, the handler function *appears* to be passed
 directly to the ``custom_id`` field. How is this possible?
 
 The trick is, the :meth:`.DiscordInteractions.custom_handler` decorator will
-actually generate a custom ID string (a :py:func:`uuid.uuid4`). It will return
+actually generate a custom ID string (a :func:`uuid.uuid4`). It will return
 this custom ID string in place of the function, after it adds it to the
 internal :attr:`.DiscordInteractions.custom_id_handlers` attribute.
 This means that the line ``custom_id=handle_click`` is actually passing a
@@ -239,12 +239,6 @@ Full API
 --------
 
 .. autoclass:: flask_discord_interactions.Component
-    :members:
-
-|
-
-.. autoclass:: flask_discord_interactions.CustomIdComponent
-    :show-inheritance:
     :members:
 
 |

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,14 +12,15 @@
 #
 import os
 import sys
-sys.path.insert(0, os.path.abspath('..'))
+
+sys.path.insert(0, os.path.abspath(".."))
 
 
 # -- Project information -----------------------------------------------------
 
-project = 'Flask-Discord-Interactions'
-copyright = '2021, Brooke Chalmers'
-author = 'Brooke Chalmers'
+project = "Flask-Discord-Interactions"
+copyright = "2022, Brooke Chalmers"
+author = "Brooke Chalmers"
 
 
 # -- General configuration ---------------------------------------------------
@@ -27,23 +28,20 @@ author = 'Brooke Chalmers'
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = [
-    "sphinx.ext.autodoc",
-    "sphinx.ext.napoleon",
-    "sphinx.ext.intersphinx"
-]
+extensions = ["sphinx.ext.autodoc", "sphinx.ext.napoleon", "sphinx.ext.intersphinx"]
 
 intersphinx_mapping = {
-  'py': ('https://docs.python.org/3', None),
+    "py": ("https://docs.python.org/3", None),
+    "requests": ("https://docs.python-requests.org/en/master/", None),
 }
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 
 # -- Options for HTML output -------------------------------------------------
@@ -51,9 +49,9 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'alabaster'
+html_theme = "alabaster"
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = ["_static"]

--- a/docs/message.rst
+++ b/docs/message.rst
@@ -69,12 +69,19 @@ For followup messages (*not* the initial response), you can also attach files:
             print("Sending a file")
             ctx.send(Message(
                 content="Sending a file",
-                file=("README.md", open("README.md", "r"), "text/markdown")))
+                file=("README.md", open("README.md", "rb"), "text/markdown")))
 
         thread = threading.Thread(target=do_followup)
         thread.start()
 
         return "Sending an original message"
+
+Pass files as a tuple, containing:
+- The filename
+- A file object (typically the result of a call to ``open(filename, "rb")`` , but you could use something like :class:`io.BytesIO` too)
+- Optionally, the content-type of the file
+
+See the ``files`` parameter of :func:`requests.request` for details.
 
 The ``allowed_mentions`` parameter can be used to restrict which users and
 roles the message should mention. It is a good idea to use this whenever your

--- a/docs/message.rst
+++ b/docs/message.rst
@@ -77,9 +77,11 @@ For followup messages (*not* the initial response), you can also attach files:
         return "Sending an original message"
 
 Pass files as a tuple, containing:
-- The filename
-- A file object (typically the result of a call to ``open(filename, "rb")`` , but you could use something like :class:`io.BytesIO` too)
-- Optionally, the content-type of the file
+
+* The filename
+* A file object (typically the result of a call to ``open(filename, "rb")`` ,
+  but you could use something like :class:`io.BytesIO` too)
+* Optionally, the content-type of the file
 
 See the ``files`` parameter of :func:`requests.request` for details.
 

--- a/docs/options.rst
+++ b/docs/options.rst
@@ -59,7 +59,7 @@ Choices
 -------
 
 To specify a list of choices the user can choose from, you can use Python's
-:py:class:`enum.Enum` class.
+:class:`enum.Enum` class.
 
 .. code-block:: python
 
@@ -83,7 +83,7 @@ choices:
         "What is the animal you hate the most?"
         return f"{ctx.author.display_name} hates {choice}s."
 
-You can also use an :py:class:`enum.IntEnum` to receive the value as an integer
+You can also use an :class:`enum.IntEnum` to receive the value as an integer
 instead of a string:
 
 .. code-block:: python

--- a/docs/quart.rst
+++ b/docs/quart.rst
@@ -4,7 +4,7 @@ Using Asyncio with Quart
 ========================
 
 `Quart <https://pgjones.gitlab.io/quart/>`_ is a Python web framework designed
-to have a similar API to Flask, but using :py:mod:`asyncio`.
+to have a similar API to Flask, but using :mod:`asyncio`.
 
 .. code-block:: python
 

--- a/docs/workers.rst
+++ b/docs/workers.rst
@@ -151,7 +151,7 @@ Custom IDs
 
 When declaring a custom ID handler without specifying the custom ID,
 te :meth:`.DiscordInteractions.custom_handler` decorator will
-actually generate a custom ID string itself (a :py:func:`uuid.uuid4`). It will return
+actually generate a custom ID string itself (a :func:`uuid.uuid4`). It will return
 this custom ID string in place of the function.
 
 This strategy works great for development, but can lead to some frustrating

--- a/flask_discord_interactions/models/message.py
+++ b/flask_discord_interactions/models/message.py
@@ -52,8 +52,15 @@ class Message(LoadableDataclass):
         interactions / custom ID handlers.
     file
         The file to attach to the message. Only valid for outgoing webhooks.
+        Pass a 2-tuple containing the file name and a file object, e.g.
+
+        .. code-block:: python
+
+            ("README.md", open("README.md", "rb"))
+
+        See the ``files`` parameter of :func:`requests.request` for details.
     files
-        An array of files to attach to the message. Specify just one of
+        A list of files to attach to the message. Specify just one of
         ``file`` or ``files``. Only valid for outgoing webhooks.
     components
         An array of :class:`.Component` objects representing message


### PR DESCRIPTION
Closes #71. Adds information on what the `tuple` represents, as well as a link to the Requests library docs for more info.