### PR TITLE
fixed autocomplete when returning a list of dicts

### DIFF
--- a/flask_discord_interactions/models/autocomplete.py
+++ b/flask_discord_interactions/models/autocomplete.py
@@ -27,7 +27,7 @@ class AutocompleteResult:
         your command.
     """
 
-    def __init__(self, choices={}):
+    def __init__(self, choices=[]):
         self.choices = choices
 
     def dump(self):

--- a/flask_discord_interactions/models/autocomplete.py
+++ b/flask_discord_interactions/models/autocomplete.py
@@ -35,10 +35,7 @@ class AutocompleteResult:
         return {
             "type": ResponseType.APPLICATION_COMMAND_AUTOCOMPLETE_RESULT,
             "data": {
-                "choices": [
-                    {"name": choice, "value": value}
-                    for choice, value in self.choices.items()
-                ]
+                "choices": self.choices
             },
         }
 
@@ -61,6 +58,8 @@ class AutocompleteResult:
         if isinstance(value, AutocompleteResult):
             return value
         elif isinstance(value, dict):
+            return AutocompleteResult([value])
+        elif isinstance(value, list) and all(isinstance(choice, dict) for choice in value):
             return AutocompleteResult(value)
         elif isinstance(value, list):
-            return AutocompleteResult({choice: choice for choice in value})
+            return AutocompleteResult([{"name": str(choice), "value":choice} for choice in value])


### PR DESCRIPTION
This pull requests fixes the outcome of an autocomplete in some cases. Before this fix, the lib ran into issues when returning a list of choice dicts as an autocomplete result.

**I changed the behavior of the `AutocompleteResult` object in the following way:**

- Property `choices` is now always a list of dicts
- If a list of dicts is passed it will be forwarded to the object without change
- If only one choice dict is passed as result, it will be put in a list as the only item
- If a list with only the values is passed, it will be transformed in a list of choice dicts where `name` and `value` are the same