### PR TITLE
fix missing `dump_handler` funcion for modals

### DIFF
--- a/examples/modals.py
+++ b/examples/modals.py
@@ -84,7 +84,7 @@ def modal(ctx):
 
 @discord.custom_handler()
 def example_modal_2(ctx):
-    return f"Hello {ctx.get_component('name').value}!"
+    return Message(f"Hello {ctx.get_component('name').value}!", update=True)
 
 
 @discord.custom_handler()

--- a/examples/modals.py
+++ b/examples/modals.py
@@ -15,6 +15,7 @@ from flask_discord_interactions import (
     TextInput,
     TextStyles,
     ActionRow,
+    Button,
 )
 
 app = Flask(__name__)
@@ -79,6 +80,40 @@ def modal(ctx):
         ),
     ]
     return Modal("example_modal", "Tell me about yourself", fields)
+
+
+@discord.custom_handler()
+def example_modal_2(ctx):
+    return f"Hello {ctx.get_component('name').value}!"
+
+
+@discord.custom_handler()
+def launch_modal(ctx):
+    return Modal(
+        example_modal_2,
+        "Tell me about yourself",
+        [
+            ActionRow(
+                [
+                    TextInput(
+                        custom_id="name",
+                        label="What's your name?",
+                        placeholder="John Doe",
+                        style=TextStyles.SHORT,
+                        required=True,
+                    )
+                ]
+            )
+        ],
+    )
+
+
+@discord.command()
+def launch_modal_from_button(ctx):
+    return Message(
+        content="Launch Modal",
+        components=[ActionRow([Button(custom_id=launch_modal, label="Launch Modal")])],
+    )
 
 
 discord.set_route("/interactions")

--- a/flask_discord_interactions/discord.py
+++ b/flask_discord_interactions/discord.py
@@ -603,7 +603,7 @@ class DiscordInteractions(DiscordInteractionsBlueprint):
                 return jsonify(self.run_autocomplete(request.json).dump())
 
             elif interaction_type == InteractionType.MODAL_SUBMIT:
-                return jsonify(self.run_handler(request.json, allow_modal=False).dump())
+                return jsonify(self.run_handler(request.json, allow_modal=False).dump_handler())
 
             else:
                 raise RuntimeWarning(

--- a/flask_discord_interactions/models/modal.py
+++ b/flask_discord_interactions/models/modal.py
@@ -72,3 +72,7 @@ class Modal(LoadableDataclass):
                 "components": self.dump_components(),
             },
         }
+
+    def dump_handler(self):
+        "Return a modal in component handlers."
+        return self.dump()

--- a/flask_discord_interactions/models/modal.py
+++ b/flask_discord_interactions/models/modal.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import List
+from typing import List, Union
 
 from flask_discord_interactions.models.utils import LoadableDataclass
 from flask_discord_interactions.models.component import Component, ComponentType

--- a/flask_discord_interactions/models/modal.py
+++ b/flask_discord_interactions/models/modal.py
@@ -22,7 +22,7 @@ class Modal(LoadableDataclass):
         Must have at least 1 row, at most 5 rows.
     """
 
-    custom_id: str = None
+    custom_id: Union[str, list] = None
     title: str = None
     components: List[Component] = None
 


### PR DESCRIPTION
**Checklist**
This pull request...

- [x] Fixes a bug
- [ ] Adds new functionality
- [ ] Updates documentation and/or examples
- [ ] Adds tests
- [ ] Is a **breaking** change -- existing code written for this library may need to be rewritten to work after these changes.

**Description**
This request fixes an issue I ran into when playing around with modals. The `Modal` class was missing the dump method for custom handlers. My quick solution is to just add that method and return the normal dump result in it. Please let me know if you have any better ideas.