### PR TITLE
fixed timestamp valueerrors in some rare cases

### DIFF
--- a/flask_discord_interactions/models/message.py
+++ b/flask_discord_interactions/models/message.py
@@ -111,12 +111,22 @@ class Message(LoadableDataclass):
                 self.Message_type = ResponseType.CHANNEL_MESSAGE_WITH_SOURCE
 
         if isinstance(self.timestamp, str):
-            self.timestamp = datetime.strptime(self.timestamp, "%Y-%m-%dT%H:%M:%S.%f%z")
+            try:
+                self.timestamp = datetime.strptime(self.timestamp, "%Y-%m-%dT%H:%M:%S.%f%z")
+            except ValueError:
+                # see pr #79 for reference
+                self.timestamp = datetime.strptime(self.timestamp, "%Y-%m-%dT%H:%M:%S%z")
+
 
         if isinstance(self.edited_timestamp, str):
-            self.edited_timestamp = datetime.strptime(
-                self.edited_timestamp, "%Y-%m-%dT%H:%M:%S.%f%z"
-            )
+            try:
+                self.edited_timestamp = datetime.strptime(
+                    self.edited_timestamp, "%Y-%m-%dT%H:%M:%S.%f%z"
+                )
+            except ValueError:
+                # see pr #79 for reference
+                self.edited_timestamp = datetime.strptime(self.edited_timestamp, "%Y-%m-%dT%H:%M:%S%z")
+
 
         if isinstance(self.author, dict):
             self.author = Member.from_dict(self.author)

--- a/flask_discord_interactions/models/message.py
+++ b/flask_discord_interactions/models/message.py
@@ -111,21 +111,11 @@ class Message(LoadableDataclass):
                 self.Message_type = ResponseType.CHANNEL_MESSAGE_WITH_SOURCE
 
         if isinstance(self.timestamp, str):
-            try:
-                self.timestamp = datetime.strptime(self.timestamp, "%Y-%m-%dT%H:%M:%S.%f%z")
-            except ValueError:
-                # see pr #79 for reference
-                self.timestamp = datetime.strptime(self.timestamp, "%Y-%m-%dT%H:%M:%S%z")
+            self.timestamp = datetime.fromisoformat(self.timestamp)
 
 
         if isinstance(self.edited_timestamp, str):
-            try:
-                self.edited_timestamp = datetime.strptime(
-                    self.edited_timestamp, "%Y-%m-%dT%H:%M:%S.%f%z"
-                )
-            except ValueError:
-                # see pr #79 for reference
-                self.edited_timestamp = datetime.strptime(self.edited_timestamp, "%Y-%m-%dT%H:%M:%S%z")
+            self.edited_timestamp = datetime.fromisoformat(self.edited_timestamp)
 
 
         if isinstance(self.author, dict):


### PR DESCRIPTION
This is actually a quite funny one. With a probability of 0.1% an error occured stating that the incoming timestamp has the wrong format. This should be fixed now. The error is now catched and the formatting will be retried with another format not containing the millis.