### PR TITLE
Perms v2

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2021 Brooke Chalmers
+Copyright (c) 2022 Brooke Chalmers and contributors.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -9,6 +9,7 @@ API Reference
     context.rst
     options.rst
     autocomplete.rst
+    modal.rst
     message.rst
     client.rst
     components.rst

--- a/docs/permissions.rst
+++ b/docs/permissions.rst
@@ -64,7 +64,7 @@ Subcommands and Command Groups
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Discord only supports attaching permissions overwrites to top-level commands.
-Thus, there are no ``permissions`` parameters for the
+Thus, there is no ``permissions`` parameter for the
 :meth:`.SlashCommandGroup.command` decorator. However, you can still set
 permissions for an entire tree of subcommands using the
 :meth:`.DiscordInteractions.command_group` function.

--- a/docs/permissions.rst
+++ b/docs/permissions.rst
@@ -5,8 +5,35 @@ Discord allows defining permissions for each application command in a specific g
 or at the global level. Flask-Discord-Interactions provides a Permission class
 and two major ways of setting the permissions of a command.
 
+Default member Permissions
+--------------------------
+
+This field represents a permission integer like it is also used in channel overwrites and role permissions and
+determines the permissions a guild member needs to have in order to execute that command.
+
+Let's say you want to have a `/setup` command that is locked to members who have the permissions to manage channels and to manage roles.
+The permission integer for this case would be ``268435472``.
+A helping hand to calculate that permissions can be found `here <https://finitereality.github.io/permissions-calculator>`_.
+
+By simply putting the number shown above into the ``default_member_permissions``, the command is locked.
+
+.. code-block:: python
+
+    @discord.command(default_member_permissions=268435472)
+    def setup(ctx):
+        "Only members with channel- and rolemanagament permissions can run this"
+
+        return "You have the right permissions! Setting up now..."
+
+Setting specific overwrites
+---------------------------
+
+.. warning::
+   The methods below will require an extra oauth scope granted by a server owner as of discord's revamp of slash command permissions.
+   It's highly recommended to use the ``default_member_permissions`` field instead,
+
 Permission class
-----------------
+^^^^^^^^^^^^^^^^
 
 The :class:`.Permission` class accepts either a role ID or a user ID.
 
@@ -15,12 +42,12 @@ The :class:`.Permission` class accepts either a role ID or a user ID.
 
 
 Command constructor
--------------------
+^^^^^^^^^^^^^^^^^^^
 
 You can define permissions when defining a command. These will be
 registered immediately after your command is registered.
 
-You can set the ``default_permission``, then use the ``permissions`` parameter
+You can use the ``permissions`` parameter
 to specify any overwrites.
 
 .. code-block:: python
@@ -34,10 +61,10 @@ to specify any overwrites.
         return "You have permissions!"
 
 Subcommands and Command Groups
-------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Discord only supports attaching permissions overwrites to top-level commands.
-Thus, there are no ``default_permission`` or ``permissions`` parameters for the
+Thus, there are no ``permissions`` parameters for the
 :meth:`.SlashCommandGroup.command` decorator. However, you can still set
 permissions for an entire tree of subcommands using the
 :meth:`.DiscordInteractions.command_group` function.
@@ -55,7 +82,7 @@ permissions for an entire tree of subcommands using the
         return "You have unlocked the secret subcommand!"
 
 Context object
---------------
+^^^^^^^^^^^^^^
 
 You can also use the :meth:`.Context.overwrite_permissions` method to overwrite
 the permissions for a command. By default, this is the command currently

--- a/docs/permissions.rst
+++ b/docs/permissions.rst
@@ -8,7 +8,7 @@ and two major ways of setting the permissions of a command.
 Default member Permissions
 --------------------------
 
-This field represents a permission integer like it is also used in channel overwrites and role permissions and
+This field represents a permission integer like it is used in channel overwrites and role permissions and
 determines the permissions a guild member needs to have in order to execute that command.
 
 Let's say you want to have a `/setup` command that is locked to members who have the permissions to manage channels and to manage roles.
@@ -21,7 +21,7 @@ By simply putting the number shown above into the ``default_member_permissions``
 
     @discord.command(default_member_permissions=268435472)
     def setup(ctx):
-        "Only members with channel- and rolemanagament permissions can run this"
+        "Only members with channel- and role-managament permissions can run this"
 
         return "You have the right permissions! Setting up now..."
 
@@ -29,8 +29,8 @@ Setting specific overwrites
 ---------------------------
 
 .. warning::
-   The methods below will require an extra oauth scope granted by a server owner as of discord's revamp of slash command permissions.
-   It's highly recommended to use the ``default_member_permissions`` field instead,
+   The methods below will require an extra oauth scope granted by a server admin as of discord's rewrite of slash command permissions.
+   It's highly recommended to use the ``default_member_permissions`` field instead.
 
 Permission class
 ^^^^^^^^^^^^^^^^

--- a/examples/permissions.py
+++ b/examples/permissions.py
@@ -17,6 +17,11 @@ app.config["DISCORD_CLIENT_SECRET"] = os.environ["DISCORD_CLIENT_SECRET"]
 
 discord.update_commands()
 
+@discord.command(default_member_permissions=4)
+def blacklist(ctx, user):
+    "Only members with the 'Ban members' permission can use this command"
+    return f"{user.username} has been blacklisted!"
+
 
 @discord.command(
     default_permission=False, permissions=[Permission(role="786840072891662336")]

--- a/examples/permissions.py
+++ b/examples/permissions.py
@@ -5,7 +5,7 @@ from flask import Flask
 
 sys.path.insert(1, ".")
 
-from flask_discord_interactions import DiscordInteractions, Permission
+from flask_discord_interactions import DiscordInteractions, Permission, Member
 
 
 app = Flask(__name__)
@@ -17,8 +17,9 @@ app.config["DISCORD_CLIENT_SECRET"] = os.environ["DISCORD_CLIENT_SECRET"]
 
 discord.update_commands()
 
+
 @discord.command(default_member_permissions=4)
-def blacklist(ctx, user):
+def blacklist(ctx, user: Member):
     "Only members with the 'Ban members' permission can use this command"
     return f"{user.username} has been blacklisted!"
 

--- a/flask_discord_interactions/command.py
+++ b/flask_discord_interactions/command.py
@@ -51,7 +51,7 @@ class Command:
         value to ``ApplicationCommandType.CHAT_INPUT``.
     default_permission
         Deprecated as of 1.4.x! Whether the command is enabled by default.
-    default_member_permissons
+    default_member_permissions
         A permission integer defining the required permissions a user must have to run the command
     permissions
         List of permission overwrites.
@@ -88,10 +88,7 @@ class Command:
             self.name = command.__name__
 
         if not 1 <= len(self.name) <= 32:
-            raise ValueError(
-                f"Error adding command {self.name}: "
-                "Command name must be between 1 and 32 characters."
-            )
+            raise ValueError(f"Error adding command {self.name}: " "Command name must be between 1 and 32 characters.")
         if self.type is ApplicationCommandType.CHAT_INPUT:
             if self.description is None:
                 self.description = command.__doc__ or "No description"
@@ -109,8 +106,7 @@ class Command:
                 )
             if not 1 <= len(self.description) <= 100:
                 raise ValueError(
-                    f"Error adding command {self.name}: "
-                    "Command description must be between 1 and 100 characters."
+                    f"Error adding command {self.name}: " "Command description must be between 1 and 100 characters."
                 )
         else:
             self.description = None
@@ -118,9 +114,7 @@ class Command:
         self.is_async = inspect.iscoroutinefunction(self.command)
 
         if self.options:
-            self.options = [
-                (o.dump() if isinstance(o, Option) else o) for o in self.options
-            ]
+            self.options = [(o.dump() if isinstance(o, Option) else o) for o in self.options]
 
         if self.type is ApplicationCommandType.CHAT_INPUT and self.options is None:
             sig = inspect.signature(self.command)
@@ -164,9 +158,7 @@ class Command:
 
                 option = {
                     "name": parameter.name,
-                    "description": self.annotations.get(
-                        parameter.name, "No description"
-                    ),
+                    "description": self.annotations.get(parameter.name, "No description"),
                     "type": ptype,
                     "required": (parameter.default == parameter.empty),
                     "autocomplete": autocomplete,
@@ -181,9 +173,7 @@ class Command:
                         value_type = str
 
                     for name, member in annotation.__members__.items():
-                        choices.append(
-                            {"name": name, "value": value_type(member.value)}
-                        )
+                        choices.append({"name": name, "value": value_type(member.value)})
 
                     option["choices"] = choices
 
@@ -251,7 +241,7 @@ class Command:
         if hasattr(self, "default_permission"):
             data["default_permission"] = self.default_member_permissions
             warnings.warn(
-                "Deprecated! As of v1.4.x, the old default_permisson is deprecated in favor of "
+                "Deprecated! As of v1.4.x, the old default_permission is deprecated in favor of "
                 "the new default_member_permissions",
                 DeprecationWarning,
                 stacklevel=2,
@@ -393,6 +383,8 @@ class SlashCommandGroup(SlashCommandSubgroup):
         get an :class:`AsyncContext` instead of a :class:`Context`.)
     default_permission
         Whether the subgroup is enabled by default. Default is True.
+    default_member_permissions:
+        Permission integer setting permission defaults for a command
     permissions
         List of permission overwrites. These apply to all subcommands of this
         group.

--- a/flask_discord_interactions/command.py
+++ b/flask_discord_interactions/command.py
@@ -253,7 +253,7 @@ class Command:
             )
 
         if self.default_member_permissions:
-            data["default_member_permissions"] = self.default_member_permissions
+            data["default_member_permissions"] = str(self.default_member_permissions)
 
         if self.dm_permission:
             data["dm_permission"] = self.dm_permission

--- a/flask_discord_interactions/command.py
+++ b/flask_discord_interactions/command.py
@@ -244,7 +244,7 @@ class Command:
 
         # Keeping this here not to break any bots using the old system
         if self.default_permission is not None:
-            data["default_permission"] = self.default_member_permissions
+            data["default_permission"] = self.default_permission
             warnings.warn(
                 "Deprecated! As of v1.5, the old default_permission is deprecated in favor of "
                 "the new default_member_permissions",

--- a/flask_discord_interactions/command.py
+++ b/flask_discord_interactions/command.py
@@ -50,7 +50,7 @@ class Command:
         The value is in ``ApplicationCommandType``. If omitted, set the default
         value to ``ApplicationCommandType.CHAT_INPUT``.
     default_permission
-        Deprecated as of 1.4.x! Whether the command is enabled by default.
+        Deprecated as of v1.5! Whether the command is enabled by default.
     default_member_permissions
         A permission integer defining the required permissions a user must have to run the command
     dm_permission
@@ -246,7 +246,7 @@ class Command:
         if self.default_permission is not None:
             data["default_permission"] = self.default_member_permissions
             warnings.warn(
-                "Deprecated! As of v1.4.x, the old default_permission is deprecated in favor of "
+                "Deprecated! As of v1.5, the old default_permission is deprecated in favor of "
                 "the new default_member_permissions",
                 DeprecationWarning,
                 stacklevel=2,

--- a/flask_discord_interactions/command.py
+++ b/flask_discord_interactions/command.py
@@ -53,6 +53,8 @@ class Command:
         Deprecated as of 1.4.x! Whether the command is enabled by default.
     default_member_permissions
         A permission integer defining the required permissions a user must have to run the command
+    dm_permission
+        Indicates whether the command can be used in DMs
     permissions
         List of permission overwrites.
     discord
@@ -70,6 +72,7 @@ class Command:
         command_type=ApplicationCommandType.CHAT_INPUT,
         default_permission=None,
         default_member_permissions=None,
+        dm_permission=None,
         permissions=None,
         discord=None,
     ):
@@ -81,6 +84,7 @@ class Command:
         self.type = command_type
         self.default_permission = default_permission
         self.default_member_permissions = default_member_permissions
+        self.dm_permission = dm_permission
         self.permissions = permissions or []
         self.discord = discord
 
@@ -232,13 +236,14 @@ class Command:
     def dump(self):
         "Returns this command as a dict for registration with the Discord API."
         data = {
+            "type": self.type,
             "name": self.name,
             "description": self.description,
             "options": self.options,
         }
 
         # Keeping this here not to break any bots using the old system
-        if hasattr(self, "default_permission"):
+        if self.default_permission is not None:
             data["default_permission"] = self.default_member_permissions
             warnings.warn(
                 "Deprecated! As of v1.4.x, the old default_permission is deprecated in favor of "
@@ -247,11 +252,11 @@ class Command:
                 stacklevel=2,
             )
 
-        if hasattr(self, "default_member_permissions"):
+        if self.default_member_permissions:
             data["default_member_permissions"] = self.default_member_permissions
 
-        if hasattr(self, "type"):
-            data["type"] = self.type
+        if self.dm_permission:
+            data["dm_permission"] = self.dm_permission
 
         return data
 
@@ -305,6 +310,7 @@ class SlashCommandSubgroup(Command):
 
         self.default_permission = None
         self.default_member_permissions = None
+        self.dm_permission = None
         self.permissions = []
 
         self.is_async = is_async
@@ -385,6 +391,8 @@ class SlashCommandGroup(SlashCommandSubgroup):
         Whether the subgroup is enabled by default. Default is True.
     default_member_permissions:
         Permission integer setting permission defaults for a command
+    dm_permission
+        Indicates whether the command can be used in DMs
     permissions
         List of permission overwrites. These apply to all subcommands of this
         group.
@@ -397,6 +405,7 @@ class SlashCommandGroup(SlashCommandSubgroup):
         is_async=False,
         default_permission=None,
         default_member_permissions=None,
+        dm_permission=None,
         permissions=None,
     ):
         self.name = name
@@ -406,6 +415,7 @@ class SlashCommandGroup(SlashCommandSubgroup):
 
         self.default_permission = default_permission
         self.default_member_permissions = default_member_permissions
+        self.dm_permission = dm_permission
         self.permissions = permissions or []
 
         self.is_async = is_async

--- a/flask_discord_interactions/discord.py
+++ b/flask_discord_interactions/discord.py
@@ -77,7 +77,7 @@ class DiscordInteractionsBlueprint:
         type
             The ``ApplicationCommandType`` of the command.
         default_permission
-            Deprecated as of 1.4.x! Whether the command is enabled by default.
+            Deprecated as of v1.5! Whether the command is enabled by default.
         default_member_permissions
             A permission integer defining the required permissions a user must have to run the command
         dm_permission
@@ -144,7 +144,7 @@ class DiscordInteractionsBlueprint:
         type
             The ``ApplicationCommandType`` of the command.
         default_permission
-            Deprecated as of 1.4.x! Whether the command is enabled by default.
+            Deprecated as of v1.5! Whether the command is enabled by default.
         default_member_permissions
             A permission integer defining the required permissions a user must have to run the command
         dm_permission
@@ -195,7 +195,7 @@ class DiscordInteractionsBlueprint:
             Whether the subgroup should be considered async (if subcommands
             get an :class:`.AsyncContext` instead of a :class:`Context`.)
         default_permission
-            Deprecated as of 1.4.x! Whether the command is enabled by default.
+            Deprecated as of v1.5! Whether the command is enabled by default.
         default_member_permissions
             A permission integer defining the required permissions a user must have to run the command
         dm_permission

--- a/flask_discord_interactions/discord.py
+++ b/flask_discord_interactions/discord.py
@@ -54,6 +54,7 @@ class DiscordInteractionsBlueprint:
         type=ApplicationCommandType.CHAT_INPUT,
         default_permission=None,
         default_member_permissions=None,
+        dm_permission=None,
         permissions=None,
     ):
         """
@@ -79,6 +80,8 @@ class DiscordInteractionsBlueprint:
             Deprecated as of 1.4.x! Whether the command is enabled by default.
         default_member_permissions
             A permission integer defining the required permissions a user must have to run the command
+        dm_permission
+            Indicates whether the command can be used in DMs
         permissions
             List of permission overwrites.
         """
@@ -90,7 +93,8 @@ class DiscordInteractionsBlueprint:
             annotations,
             type,
             default_permission,
-            default_member_permissions
+            default_member_permissions,
+            dm_permission,
             permissions,
             self,
         )
@@ -119,6 +123,7 @@ class DiscordInteractionsBlueprint:
         type=ApplicationCommandType.CHAT_INPUT,
         default_permission=None,
         default_member_permissions=None,
+        dm_permission=None,
         permissions=None,
     ):
         """
@@ -142,6 +147,8 @@ class DiscordInteractionsBlueprint:
             Deprecated as of 1.4.x! Whether the command is enabled by default.
         default_member_permissions
             A permission integer defining the required permissions a user must have to run the command
+        dm_permission
+            Indicates whether the command can be used in DMs
         permissions
             List of permission overwrites.
         """
@@ -157,6 +164,7 @@ class DiscordInteractionsBlueprint:
                 type,
                 default_permission,
                 default_member_permissions,
+                dm_permission,
                 permissions,
             )
             return command
@@ -170,6 +178,7 @@ class DiscordInteractionsBlueprint:
         is_async=False,
         default_permission=None,
         default_member_permissions=None,
+        dm_permission=None,
         permissions=None,
     ):
         """
@@ -189,12 +198,20 @@ class DiscordInteractionsBlueprint:
             Deprecated as of 1.4.x! Whether the command is enabled by default.
         default_member_permissions
             A permission integer defining the required permissions a user must have to run the command
+        dm_permission
+            Indicates whether the command canbe used in DMs
         permissions
             List of permission overwrites. These apply to the entire group.
         """
 
         group = SlashCommandGroup(
-            name, description, is_async, default_permission, default_member_permissions, permissions
+            name,
+            description,
+            is_async,
+            default_permission,
+            default_member_permissions,
+            dm_permission,
+            permissions,
         )
         self.discord_commands[name] = group
         return group

--- a/flask_discord_interactions/discord.py
+++ b/flask_discord_interactions/discord.py
@@ -53,6 +53,7 @@ class DiscordInteractionsBlueprint:
         annotations=None,
         type=ApplicationCommandType.CHAT_INPUT,
         default_permission=None,
+        default_member_permissions=None,
         permissions=None,
     ):
         """
@@ -75,7 +76,9 @@ class DiscordInteractionsBlueprint:
         type
             The ``ApplicationCommandType`` of the command.
         default_permission
-            Whether the command is enabled by default. Default is True.
+            Deprecated as of 1.4.x! Whether the command is enabled by default.
+        default_member_permissions
+            A permission integer defining the required permissions a user must have to run the command
         permissions
             List of permission overwrites.
         """
@@ -87,6 +90,7 @@ class DiscordInteractionsBlueprint:
             annotations,
             type,
             default_permission,
+            default_member_permissions
             permissions,
             self,
         )
@@ -114,6 +118,7 @@ class DiscordInteractionsBlueprint:
         annotations=None,
         type=ApplicationCommandType.CHAT_INPUT,
         default_permission=None,
+        default_member_permissions=None,
         permissions=None,
     ):
         """
@@ -134,7 +139,9 @@ class DiscordInteractionsBlueprint:
         type
             The ``ApplicationCommandType`` of the command.
         default_permission
-            Whether the command is enabled by default. Default is True.
+            Deprecated as of 1.4.x! Whether the command is enabled by default.
+        default_member_permissions
+            A permission integer defining the required permissions a user must have to run the command
         permissions
             List of permission overwrites.
         """
@@ -149,6 +156,7 @@ class DiscordInteractionsBlueprint:
                 annotations,
                 type,
                 default_permission,
+                default_member_permissions,
                 permissions,
             )
             return command
@@ -161,6 +169,7 @@ class DiscordInteractionsBlueprint:
         description="No description",
         is_async=False,
         default_permission=None,
+        default_member_permissions=None,
         permissions=None,
     ):
         """
@@ -177,13 +186,15 @@ class DiscordInteractionsBlueprint:
             Whether the subgroup should be considered async (if subcommands
             get an :class:`.AsyncContext` instead of a :class:`Context`.)
         default_permission
-            Whether the command group is enabled by default.
+            Deprecated as of 1.4.x! Whether the command is enabled by default.
+        default_member_permissions
+            A permission integer defining the required permissions a user must have to run the command
         permissions
             List of permission overwrites. These apply to the entire group.
         """
 
         group = SlashCommandGroup(
-            name, description, is_async, default_permission, permissions
+            name, description, is_async, default_permission, default_member_permissions, permissions
         )
         self.discord_commands[name] = group
         return group

--- a/flask_discord_interactions/models/option.py
+++ b/flask_discord_interactions/models/option.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Optional
 
 from flask_discord_interactions.models import User, Member, Channel, Role
 
@@ -34,6 +34,16 @@ class Option:
         The description of the option. Defaults to "No description."
     required
         Whether the option is required. Defaults to ``False``.
+    options:
+        A list of further options if the option is a subcommand or a subcommand group.
+    choices
+        A list of choices for the option.
+    channel_types:
+        A list of :class:`.ChannelType` for the option.
+    min_value
+        The minimum value of the option if the option is numeric.
+    max_value
+        The maximum value of the option if the option is numeric.
     autocomplete
         Whether the option should be autocompleted. Defaults to ``False``.
         Set to ``True`` if you have an autocomplete handler for this command.
@@ -51,10 +61,16 @@ class Option:
 
     description: str = "No description"
     required: bool = False
+    options: Optional[list] = None
+    choices: Optional[list] = None
+    channel_types: Optional[list] = None
+    min_value: Optional[int] = None
+    max_value: Optional[int] = None
+
     autocomplete: bool = False
 
     value: Any = None
-    focused: bool = None
+    focused: Optional[bool] = None
 
     def __post_init__(self):
         if isinstance(self.type, type):
@@ -92,6 +108,11 @@ class Option:
             "type": self.type,
             "description": self.description,
             "required": self.required,
+            "options": self.options,
+            "choices": self.choices,
+            "channel_types": self.channel_types,
+            "min_value": self.min_value,
+            "max_value": self.max_value,
             "autocomplete": self.autocomplete,
         }
         return data


### PR DESCRIPTION
Discord is currently rolling out their new permission system for slash commands. Control about permissions will shift away from the bot dev towards the server admins. On the dev side, this luckily only needs few work. In the end it's just 2 new fields coming to the command object and the old permission endpoint being locked behind another oauth2 scope.

In this pr I already implemented the 2 new fields regarding permissions. `default_member_permissions` and `dm_permission`.
The first is a permission integer to determine the permission a member that runs this command must have to use it. The second field decides whether this particular command should show up in DM's.
There will also be a deprecation warning if you try to use the old 'default_permission' field.

I did'nt update anything in the docs yet. That's still left to do.

I will keep you updated on this as soon as information is released and I get it.