### PR TITLE
fix: dm permission set to false

### DIFF
--- a/flask_discord_interactions/command.py
+++ b/flask_discord_interactions/command.py
@@ -252,10 +252,10 @@ class Command:
                 stacklevel=2,
             )
 
-        if self.default_member_permissions:
+        if self.default_member_permissions is not None:
             data["default_member_permissions"] = str(self.default_member_permissions)
 
-        if self.dm_permission:
+        if self.dm_permission is not None:
             data["dm_permission"] = self.dm_permission
 
         return data


### PR DESCRIPTION
*Checklist**
This pull request...

- [x] Fixes a bug
- [ ] Adds new functionality
- [ ] Updates documentation and/or examples
- [ ] Adds tests
- [ ] Is a **breaking** change -- existing code written for this library may need to be rewritten to work after these changes.

**Description**
When setting `dm_permission` to `false`, the field was not sent to the api. This is fixed now