### PR TITLE
only register permissions if they are actually set

### DIFF
--- a/flask_discord_interactions/command.py
+++ b/flask_discord_interactions/command.py
@@ -85,7 +85,7 @@ class Command:
         self.default_permission = default_permission
         self.default_member_permissions = default_member_permissions
         self.dm_permission = dm_permission
-        self.permissions = permissions or []
+        self.permissions = permissions
         self.discord = discord
 
         if self.name is None:
@@ -311,7 +311,7 @@ class SlashCommandSubgroup(Command):
         self.default_permission = None
         self.default_member_permissions = None
         self.dm_permission = None
-        self.permissions = []
+        self.permissions = None
 
         self.is_async = is_async
 
@@ -416,7 +416,7 @@ class SlashCommandGroup(SlashCommandSubgroup):
         self.default_permission = default_permission
         self.default_member_permissions = default_member_permissions
         self.dm_permission = dm_permission
-        self.permissions = permissions or []
+        self.permissions = permissions
 
         self.is_async = is_async
 

--- a/flask_discord_interactions/discord.py
+++ b/flask_discord_interactions/discord.py
@@ -424,7 +424,7 @@ class DiscordInteractions(DiscordInteractionsBlueprint):
 
         if guild_id:
             for command in app.discord_commands.values():
-                if not app.config["DONT_REGISTER_WITH_DISCORD"]:
+                if not app.config["DONT_REGISTER_WITH_DISCORD"] and command.permissions is not None:
                     response = requests.put(
                         url + "/" + command.id + "/permissions",
                         json={"permissions": command.dump_permissions()},


### PR DESCRIPTION
This pr fixes permission registration in some cases. When no permission overwrites were specified the lib sent an empty list to the perm endpoint, removing all admin-configured command perms. This is fixed now. The endpoint is only hit if the permissions were explicitly set.