### PR TITLE
Localization

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -15,3 +15,4 @@ API Reference
     components.rst
     quart.rst
     permissions.rst
+    localization.rst

--- a/docs/localization.rst
+++ b/docs/localization.rst
@@ -17,7 +17,7 @@ Commands and options can be localized via the ``name_localizations`` and ``descr
             "fr": "nourrir"
         },
         description_localizations={
-            "de": "Füttere einen Tier",
+            "de": "Füttere ein Tier",
             "fr": "Nourrir un animal"
         }
         options=[

--- a/docs/localization.rst
+++ b/docs/localization.rst
@@ -1,0 +1,81 @@
+Localization
+============
+
+Using localized commands, you can make your application accessible to more people speaking different languages.
+You can localize names, descriptions, options, choices and your responses.
+
+Defining a localized command
+----------------------------
+
+Commands and options can be localized via the ``name_localizations`` and ``description_localizations`` fields. For choices, only ``name_localizations`` is settable.
+
+.. code-block:: python
+
+    @discord.command(
+        name_localizations={
+            "de": "füttern",
+            "fr": "nourrir"
+        },
+        description_localizations={
+            "de": "Füttere einen Tier",
+            "fr": "Nourrir un animal"
+        }
+        options=[
+            Option(
+                type=3,
+                required=True
+                name="animal"
+                name_localizations={
+                    "de": "tier",
+                    "fr": "animal"
+                },
+                description="The animal to feed",
+                description_localizations={
+                    "de": "Das Tier, das gefüttert werden soll",
+                    "fr": "L'animal qui sera nourri"
+                }
+                choices=[
+                    Choice(
+                        name="Cow",
+                        value="cow",
+                        name_localizations={
+                            "de": "Kuh",
+                            "fr": "Vache"
+                        }
+                    ),
+                    Choice(
+                        name="Dog",
+                        value="dog",
+                        name_localizations={
+                            "de": "Hund",
+                            "fr": "Chien"
+                        }
+                    ),
+                ]
+            )
+        ]
+    )
+    def feed(ctx, animal: str):
+        """Feed an animal"""
+        ...
+
+
+Localizing your respones
+------------------------
+You can also localize your respones to the interactions. The context object contains 2 fields for that.
+Use ``locale`` and ``guild_locale`` to return your response in the appropriate language.
+
+
+.. code-block:: python
+
+    @discord.command(
+        ...
+    )
+    def feed(ctx, animal:str):
+        """Feed an animal"""
+        responses_localized = {
+            "de": "Ich habe {animal} gefüttert",
+            "fr": "J'ai nourri {animal}"
+        }
+        return responses_localized.get(ctx.locale, __default=f"I have fed {animal}")
+

--- a/docs/localization.rst
+++ b/docs/localization.rst
@@ -7,7 +7,8 @@ You can localize names, descriptions, options, choices and your responses.
 Defining a localized command
 ----------------------------
 
-Commands and options can be localized via the ``name_localizations`` and ``description_localizations`` fields. For choices, only ``name_localizations`` is settable.
+Commands and options can be localized with the ``name_localizations`` and ``description_localizations`` fields. For choices, only ``name_localizations`` is settable.
+A list of all available locales can be found `here <https://discord.com/developers/docs/reference#locales>`_.
 
 .. code-block:: python
 

--- a/examples/localization.py
+++ b/examples/localization.py
@@ -21,11 +21,15 @@ answers_localized = {"de": "Welt", "fr": "monde", "da": "verden"}
 
 @discord.command(
     name_localizations={"de": "hallo", "fr": "bonjour", "da": "hej"},
-    description_localizations={"de": "Hallo Welt", "fr": "Bonjour le monde", "da": "Hej verden"},
+    description_localizations={
+        "de": "Hallo Welt",
+        "fr": "Bonjour le monde",
+        "da": "Hej verden",
+    },
 )
 def hello(ctx):
     """Hello world"""
-    return answers_localized.get(ctx.locale, __default="World")
+    return answers_localized.get(ctx.locale, "World")
 
 
 discord.set_route("/interactions")

--- a/examples/localization.py
+++ b/examples/localization.py
@@ -1,0 +1,34 @@
+import os
+import sys
+
+from flask import Flask
+
+sys.path.insert(1, ".")
+
+from flask_discord_interactions import DiscordInteractions
+
+
+app = Flask(__name__)
+discord = DiscordInteractions(app)
+
+app.config["DISCORD_CLIENT_ID"] = os.environ["DISCORD_CLIENT_ID"]
+app.config["DISCORD_PUBLIC_KEY"] = os.environ["DISCORD_PUBLIC_KEY"]
+app.config["DISCORD_CLIENT_SECRET"] = os.environ["DISCORD_CLIENT_SECRET"]
+
+
+answers_localized = {"de": "Welt", "fr": "monde", "da": "verden"}
+
+
+@discord.command(
+    name_localizations={"de": "hallo", "fr": "bonjour", "da": "hej"},
+    description_localizations={"de": "Hallo Welt", "fr": "Bonjour le monde", "da": "Hej verden"},
+)
+def hello(ctx):
+    """Hello world"""
+    return answers_localized.get(ctx.locale, __default="World")
+
+
+discord.set_route("/interactions")
+discord.update_commands(guild_id=os.environ["TESTING_GUILD"])
+if __name__ == "__main__":
+    app.run()

--- a/flask_discord_interactions/command.py
+++ b/flask_discord_interactions/command.py
@@ -30,11 +30,15 @@ class Command:
     name
         Name for this command (appears in the Discord client). If omitted,
         infers the name based on the name of the function.
+    name_localizations
+        Localization dictionary for name field.
     description
         Description for this command (appears in the Discord client). If
         omitted, infers the description based on the docstring of the function,
         or sets the description to "No description", if ``ApplicationCommandType``
         is ``CHAT_INPUT``, else set description to ``None``.
+    description_localizations
+        Localization dictionary for description field.
     options
         Array of options that can be passed to this command. If omitted,
         infers the options based on the function parameters and type
@@ -74,6 +78,8 @@ class Command:
         default_member_permissions=None,
         dm_permission=None,
         permissions=None,
+        name_localizations=None,
+        description_localizations=None,
         discord=None,
     ):
         self.command = command
@@ -86,6 +92,8 @@ class Command:
         self.default_member_permissions = default_member_permissions
         self.dm_permission = dm_permission
         self.permissions = permissions
+        self.name_localizations = name_localizations
+        self.description_localizations = description_localizations
         self.discord = discord
 
         if self.name is None:
@@ -240,6 +248,8 @@ class Command:
             "name": self.name,
             "description": self.description,
             "options": self.options,
+            "name_localizations": self.name_localizations,
+            "description_localizations": self.description_localizations,
         }
 
         # Keeping this here not to break any bots using the old system
@@ -295,18 +305,24 @@ class SlashCommandSubgroup(Command):
     ----------
     name
         The name of this subgroup, shown in the Discord client.
+    name_localizations
+        A dict of localized names for this subgroup.
     description
         The description of this subgroup, shown in the Discord client.
+    description_localizations
+        A dict of localized descriptions for this subgroup.
     is_async
         Whether the subgroup should be considered async (if subcommands
         get an :class:`AsyncContext` instead of a :class:`Context`.)
     """
 
-    def __init__(self, name, description, is_async=False):
+    def __init__(self, name, description, name_localizations=None, description_localizations=None, is_async=False):
         self.name = name
         self.description = description
         self.subcommands = {}
         self.type = ApplicationCommandType.CHAT_INPUT
+        self.name_localizations = name_localizations
+        self.description_localizations = description_localizations
 
         self.default_permission = None
         self.default_member_permissions = None
@@ -315,7 +331,15 @@ class SlashCommandSubgroup(Command):
 
         self.is_async = is_async
 
-    def command(self, name=None, description=None, options=None, annotations=None):
+    def command(
+        self,
+        name=None,
+        description=None,
+        name_localizations=None,
+        description_localizations=None,
+        options=None,
+        annotations=None,
+    ):
         """
         Decorator to create a new Subcommand of this Subgroup.
 
@@ -323,8 +347,12 @@ class SlashCommandSubgroup(Command):
         ----------
         name
             The name of the command, as displayed in the Discord client.
+        name_localizations
+            A dict of localized names for the command.
         description
             The description of the command.
+        description_localizations
+            A dict of localized descriptions for the command.
         options
             A list of options for the command, overriding the function's
             keyword arguments.
@@ -335,7 +363,9 @@ class SlashCommandSubgroup(Command):
 
         def decorator(func):
             nonlocal name, description, options, annotations
-            subcommand = Command(func, name, description, options, annotations)
+            subcommand = Command(
+                func, name, description, name_localizations, description_localizations, options, annotations
+            )
             self.subcommands[subcommand.name] = subcommand
             return func
 
@@ -382,8 +412,12 @@ class SlashCommandGroup(SlashCommandSubgroup):
     ----------
     name
         The name of this subgroup, shown in the Discord client.
+    name_localizations
+        A dict of localized names for this subgroup.
     description
         The description of this subgroup, shown in the Discord client.
+    description_localizations
+        A dict of localized descriptions for this subgroup.
     is_async
         Whether the subgroup should be considered async (if subcommands
         get an :class:`AsyncContext` instead of a :class:`Context`.)
@@ -407,6 +441,8 @@ class SlashCommandGroup(SlashCommandSubgroup):
         default_member_permissions=None,
         dm_permission=None,
         permissions=None,
+        name_localizations=None,
+        description_localizations=None,
     ):
         self.name = name
         self.description = description
@@ -417,10 +453,19 @@ class SlashCommandGroup(SlashCommandSubgroup):
         self.default_member_permissions = default_member_permissions
         self.dm_permission = dm_permission
         self.permissions = permissions
+        self.name_localizations = name_localizations
+        self.description_localizations = description_localizations
 
         self.is_async = is_async
 
-    def subgroup(self, name, description="No description", is_async=False):
+    def subgroup(
+        self,
+        name,
+        description="No description",
+        name_localizations=None,
+        description_localizations=None,
+        is_async=False,
+    ):
         """
         Create a new :class:`SlashCommandSubroup`
         (which can contain multiple subcommands)
@@ -429,13 +474,17 @@ class SlashCommandGroup(SlashCommandSubgroup):
         ----------
         name
             The name of the subgroup, as displayed in the Discord client.
+        name_localizations
+            A dict of localized names for the subgroup.
         description
             The description of the subgroup. Defaults to "No description".
+        description_localizations
+            A dict of localized descriptions for the subgroup.
         is_async
             Whether the subgroup should be considered async (if subcommands
             get an :class:`AsyncContext` instead of a :class:`Context`.)
         """
 
-        group = SlashCommandSubgroup(name, description, is_async)
+        group = SlashCommandSubgroup(name, description, name_localizations, description_localizations, is_async)
         self.subcommands[name] = group
         return group

--- a/flask_discord_interactions/context.py
+++ b/flask_discord_interactions/context.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Any, List, Union
+from typing import Any, List, Optional, Union
 import inspect
 import itertools
 import warnings
@@ -68,6 +68,10 @@ class Context(LoadableDataclass):
     message
         The message that the invoked components are attached to.
         Only available on component interactions.
+    locale
+        The selected language of the invoking user.
+    guild_locale
+        The guild's preferred locale, if invoked in a guild
     """
 
     author: Union[Member, User] = None
@@ -86,6 +90,8 @@ class Context(LoadableDataclass):
     channels: List[Channel] = None
     roles: List[Role] = None
     message: Message = None
+    locale: Optional[str] = None
+    guild_locale: Optional[str] = None
 
     app: Any = None
     discord: Any = None
@@ -123,6 +129,8 @@ class Context(LoadableDataclass):
             command_id=data.get("data", {}).get("id"),
             custom_id=data.get("data", {}).get("custom_id") or "",
             target_id=data.get("data", {}).get("target_id"),
+            locale=data.get("locale"),
+            guild_locale=data.get("guild_locale"),
         )
 
         result.data = data

--- a/flask_discord_interactions/discord.py
+++ b/flask_discord_interactions/discord.py
@@ -353,7 +353,9 @@ class DiscordInteractions(DiscordInteractionsBlueprint):
                 "expires_in": 604800,
                 "access_token": "DONT_REGISTER_WITH_DISCORD",
             }
-            app.discord_token["expires_on"] = time.time() + app.discord_token["expires_in"] / 2
+            app.discord_token["expires_on"] = (
+                time.time() + app.discord_token["expires_in"] / 2
+            )
             return
         response = requests.post(
             app.config["DISCORD_BASE_URL"] + "/oauth2/token",
@@ -367,7 +369,9 @@ class DiscordInteractions(DiscordInteractionsBlueprint):
 
         response.raise_for_status()
         app.discord_token = response.json()
-        app.discord_token["expires_on"] = time.time() + app.discord_token["expires_in"] / 2
+        app.discord_token["expires_on"] = (
+            time.time() + app.discord_token["expires_in"] / 2
+        )
 
     def auth_headers(self, app):
         """
@@ -413,17 +417,25 @@ class DiscordInteractions(DiscordInteractionsBlueprint):
                 f"guilds/{guild_id}/commands"
             )
         else:
-            url = f"{app.config['DISCORD_BASE_URL']}/applications/" f"{app.config['DISCORD_CLIENT_ID']}/commands"
+            url = (
+                f"{app.config['DISCORD_BASE_URL']}/applications/"
+                f"{app.config['DISCORD_CLIENT_ID']}/commands"
+            )
 
         overwrite_data = [command.dump() for command in app.discord_commands.values()]
 
         if not app.config["DONT_REGISTER_WITH_DISCORD"]:
-            response = requests.put(url, json=overwrite_data, headers=self.auth_headers(app))
+            response = requests.put(
+                url, json=overwrite_data, headers=self.auth_headers(app)
+            )
 
             try:
                 response.raise_for_status()
             except requests.exceptions.HTTPError:
-                raise ValueError(f"Unable to register commands:" f"{response.status_code} {response.text}")
+                raise ValueError(
+                    f"Unable to register commands:"
+                    f"{response.status_code} {response.text}"
+                )
 
             self.throttle(response)
 
@@ -436,7 +448,10 @@ class DiscordInteractions(DiscordInteractionsBlueprint):
 
         if guild_id:
             for command in app.discord_commands.values():
-                if not app.config["DONT_REGISTER_WITH_DISCORD"] and command.permissions is not None:
+                if (
+                    not app.config["DONT_REGISTER_WITH_DISCORD"]
+                    and command.permissions is not None
+                ):
                     response = requests.put(
                         url + "/" + command.id + "/permissions",
                         json={"permissions": command.dump_permissions()},
@@ -638,10 +653,14 @@ class DiscordInteractions(DiscordInteractionsBlueprint):
                 return jsonify(self.run_autocomplete(request.json).dump())
 
             elif interaction_type == InteractionType.MODAL_SUBMIT:
-                return jsonify(self.run_handler(request.json, allow_modal=False).dump_handler())
+                return jsonify(
+                    self.run_handler(request.json, allow_modal=False).dump_handler()
+                )
 
             else:
-                raise RuntimeWarning(f"Interaction type {interaction_type} is not yet supported")
+                raise RuntimeWarning(
+                    f"Interaction type {interaction_type} is not yet supported"
+                )
 
     def set_route_async(self, route, app=None):
         """
@@ -663,7 +682,9 @@ class DiscordInteractions(DiscordInteractionsBlueprint):
             app = self.app
 
         if aiohttp is None:
-            raise ImportError("The aiohttp module is required for async usage of this " "library")
+            raise ImportError(
+                "The aiohttp module is required for async usage of this " "library"
+            )
 
         @app.route(route, methods=["POST"])
         async def interactions():
@@ -684,7 +705,9 @@ class DiscordInteractions(DiscordInteractionsBlueprint):
                 result = self.run_handler(request.json, allow_modal=False)
 
             else:
-                raise RuntimeWarning(f"Interaction type {interaction_type} is not yet supported")
+                raise RuntimeWarning(
+                    f"Interaction type {interaction_type} is not yet supported"
+                )
 
             if inspect.isawaitable(result):
                 result = await result
@@ -694,7 +717,9 @@ class DiscordInteractions(DiscordInteractionsBlueprint):
         # Set up the aiohttp ClientSession
 
         async def create_session():
-            app.discord_client_session = aiohttp.ClientSession(headers=self.auth_headers(app), raise_for_status=True)
+            app.discord_client_session = aiohttp.ClientSession(
+                headers=self.auth_headers(app), raise_for_status=True
+            )
 
         async def close_session():
             await app.discord_client_session.close()
@@ -706,4 +731,6 @@ class DiscordInteractions(DiscordInteractionsBlueprint):
         else:
             # Flask apps
             app.before_first_request(create_session)
-            atexit.register(lambda: asyncio.get_event_loop().run_until_complete(close_session()))
+            atexit.register(
+                lambda: asyncio.get_event_loop().run_until_complete(close_session())
+            )

--- a/flask_discord_interactions/models/autocomplete.py
+++ b/flask_discord_interactions/models/autocomplete.py
@@ -1,5 +1,6 @@
 from typing import Union
 from flask_discord_interactions.models.message import ResponseType
+from flask_discord_interactions.models.option import Choice
 
 
 class Autocomplete:
@@ -57,11 +58,9 @@ class AutocompleteResult:
             return value
         elif isinstance(value, dict):
             return AutocompleteResult([value])
-        elif isinstance(value, list) and all(
-            isinstance(choice, dict) for choice in value
-        ):
+        elif isinstance(value, list) and all(isinstance(choice, dict) for choice in value):
             return AutocompleteResult(value)
+        elif isinstance(value, list) and all(isinstance(choice, Choice) for choice in value):
+            return [AutocompleteResult(choice.dump()) for choice in value]
         elif isinstance(value, list):
-            return AutocompleteResult(
-                [{"name": str(choice), "value": choice} for choice in value]
-            )
+            return AutocompleteResult([{"name": str(choice), "value": choice} for choice in value])

--- a/flask_discord_interactions/models/autocomplete.py
+++ b/flask_discord_interactions/models/autocomplete.py
@@ -58,9 +58,15 @@ class AutocompleteResult:
             return value
         elif isinstance(value, dict):
             return AutocompleteResult([value])
-        elif isinstance(value, list) and all(isinstance(choice, dict) for choice in value):
+        elif isinstance(value, list) and all(
+            isinstance(choice, dict) for choice in value
+        ):
             return AutocompleteResult(value)
-        elif isinstance(value, list) and all(isinstance(choice, Choice) for choice in value):
+        elif isinstance(value, list) and all(
+            isinstance(choice, Choice) for choice in value
+        ):
             return [AutocompleteResult(choice.dump()) for choice in value]
         elif isinstance(value, list):
-            return AutocompleteResult([{"name": str(choice), "value": choice} for choice in value])
+            return AutocompleteResult(
+                [{"name": str(choice), "value": choice} for choice in value]
+            )

--- a/flask_discord_interactions/models/option.py
+++ b/flask_discord_interactions/models/option.py
@@ -27,11 +27,15 @@ class Option:
     ----------
     name
         The name of the option.
+    name_localizations
+        A dict of localizations for the name of the option.
     type
         The type of the option. Provide either a value of
         :class:`.CommandOptionType` or a type (e.g. ``str``).
     description
         The description of the option. Defaults to "No description."
+    description_localizations
+        A dict of localizations for the description of the option.
     required
         Whether the option is required. Defaults to ``False``.
     options:
@@ -66,6 +70,8 @@ class Option:
     channel_types: Optional[list] = None
     min_value: Optional[int] = None
     max_value: Optional[int] = None
+    name_localizations: Optional[dict] = None
+    description_localizations: Optional[dict] = None
 
     autocomplete: bool = False
 
@@ -105,8 +111,10 @@ class Option:
         "Return this option as as a dict for registration with Discord."
         data = {
             "name": self.name,
+            "name_localizations": self.name_localizations,
             "type": self.type,
             "description": self.description,
+            "description_localizations": self.description_localizations,
             "required": self.required,
             "options": self.options,
             "choices": self.choices,

--- a/flask_discord_interactions/models/option.py
+++ b/flask_discord_interactions/models/option.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Any, Optional
+from typing import Any, Optional, Union
 
 from flask_discord_interactions.models import User, Member, Channel, Role
 
@@ -122,5 +122,31 @@ class Option:
             "min_value": self.min_value,
             "max_value": self.max_value,
             "autocomplete": self.autocomplete,
+        }
+        return data
+
+
+@dataclass
+class Choice:
+    """
+    Represents an option choice. These can be directly set in the command or returned as autocomplete results
+    name
+        Name of the choice
+    value
+        Value of the choice
+    name_localizations
+        A dict of localizations for the name of the choice.
+    """
+
+    name: str
+    value: Union[str, int]
+    name_localizations: Optional[dict] = None
+
+    def dump(self):
+        "Return this choice as a dict for registration with Discord."
+        data = {
+            "name": self.name,
+            "value": self.value,
+            "name_localizations": self.name_localizations,
         }
         return data


### PR DESCRIPTION
# Checklist
This pull request...

- [ ] Fixes a bug
- [x] Adds new functionality
- [x] Updates documentation and/or examples
- [ ] Adds tests
- [ ] Is a **breaking** change -- existing code written for this library may need to be rewritten to work after these changes.

# Description
Discord is currently working on localization of slash commands. With this, names and description of commands, names and choices can be localized.

## What changed
- Commands and subcommands got 2 new fields: `name_localizations` and `description_localizations`. Both take dicts in form of `{"<locale>": "<localized string>"}`
- Same goes for options
- Added a `Choice` object that supports `name_localizations`
- The `Context` object got 2 new attributes:
    - `locale`  which represents the invoking user's locale
    - `guild_locale` which represents the guilds preferred locale (if invoked in a guild)
- New docs page and examples explaining everything

## Current state
This change is currently in a weird state between released and not released on discord's side. All the fields are already fully documented in the discord docs and the new context fields are already sent with every interaction. The command/option name and description localization is still in on open beta to test, locked behind a build override and not deployed to the clients yet.

