### PR TITLE
Attachments-related tweaks

### DIFF
--- a/examples/followup.py
+++ b/examples/followup.py
@@ -72,6 +72,22 @@ def delay(ctx, duration: int):
     return Message(deferred=True)
 
 
+# This can be useful if you want to send files
+@discord.command()
+def sendfile(ctx):
+    def do_sendfile():
+        ctx.edit(
+            Message(
+                file=("README.md", open("README.md", "r"), "text/markdown"),
+            )
+        )
+
+    thread = threading.Thread(target=do_sendfile)
+    thread.start()
+
+    return Message(deferred=True)
+
+
 discord.set_route("/interactions")
 discord.update_commands(guild_id=os.environ["TESTING_GUILD"])
 

--- a/flask_discord_interactions/context.py
+++ b/flask_discord_interactions/context.py
@@ -388,7 +388,7 @@ class Context(LoadableDataclass):
 
         updated = requests.patch(
             self.followup_url(message),
-            json=updated.dump_followup(),
+            **updated.dump_multipart(),
         )
         updated.raise_for_status()
 


### PR DESCRIPTION
**Checklist**
This pull request...

- [ ] Fixes a bug
- [X] Adds new functionality
- [X] Updates documentation and/or examples
- [ ] Adds tests
- [ ] Is a **breaking** change -- existing code written for this library may need to be rewritten to work after these changes.

**Description**
* `Context.edit` now sends the updated message over `multipart/form-data`, not `application/json`. This enables editing the original message to include an attachment using the `file` argument.
* A new example command in `examples/followup.py` showing how to use a deferred message and a followup to include a file as a response.