### PR TITLE
Warn when the rate limit is reached

### DIFF
--- a/flask_discord_interactions/discord.py
+++ b/flask_discord_interactions/discord.py
@@ -424,7 +424,10 @@ class DiscordInteractions(DiscordInteractionsBlueprint):
 
         if guild_id:
             for command in app.discord_commands.values():
-                if not app.config["DONT_REGISTER_WITH_DISCORD"] and command.permissions is not None:
+                if (
+                    not app.config["DONT_REGISTER_WITH_DISCORD"]
+                    and command.permissions is not None
+                ):
                     response = requests.put(
                         url + "/" + command.id + "/permissions",
                         json={"permissions": command.dump_permissions()},
@@ -473,7 +476,11 @@ class DiscordInteractions(DiscordInteractionsBlueprint):
         # rate_limit_bucket = response.headers["X-RateLimit-Bucket"]
 
         if not rate_limit_remaining:
-            time.sleep(max(rate_limit_reset - time.time(), 0))
+            wait_time = rate_limit_reset - time.time()
+            warnings.warn(
+                f"You are being rate limited. Waiting {int(wait_time)} seconds..."
+            )
+            time.sleep(max(wait_time, 0))
 
     def register_blueprint(self, blueprint, app=None):
         """


### PR DESCRIPTION

**Checklist**
This pull request...

- [ ] Fixes a bug
- [X] Adds new functionality
- [ ] Updates documentation and/or examples
- [ ] Adds tests
- [ ] Is a **breaking** change -- existing code written for this library may need to be rewritten to work after these changes.

**Description**
Prints a warning when the rate limit is reached and the program is sleeping before making another request.