### PR TITLE
Fix choice serialization in autocomplete

### DIFF
--- a/flask_discord_interactions/models/autocomplete.py
+++ b/flask_discord_interactions/models/autocomplete.py
@@ -65,7 +65,7 @@ class AutocompleteResult:
         elif isinstance(value, list) and all(
             isinstance(choice, Choice) for choice in value
         ):
-            return [AutocompleteResult(choice.dump()) for choice in value]
+            return AutocompleteResult([choice.dump() for choice in value])
         elif isinstance(value, list):
             return AutocompleteResult(
                 [{"name": str(choice), "value": choice} for choice in value]


### PR DESCRIPTION
**Checklist**
This pull request...

- [x] Fixes a bug
- [ ] Adds new functionality
- [ ] Updates documentation and/or examples
- [ ] Adds tests
- [ ] Is a **breaking** change -- existing code written for this library may need to be rewritten to work after these changes.

**Description**
When returning a list of choices as autocomplete result, dumping failed because accidentally a list was returned where it shouldn't. This is fixed now.
