### PR TITLE
Handle user commands when user is not a member (left the guild or in DM)

### DIFF
--- a/flask_discord_interactions/context.py
+++ b/flask_discord_interactions/context.py
@@ -246,7 +246,10 @@ class Context(LoadableDataclass):
         message. This method sets the `ctx.target` field.
         """
         if self.type == ApplicationCommandType.USER:
-            self.target = self.members[self.target_id]
+            if self.target_id in self.members:
+                self.target = self.members[self.target_id]
+            else:
+                self.target = self.users[self.target_id]
         elif self.type == ApplicationCommandType.MESSAGE:
             self.target = self.messages[self.target_id]
         else:


### PR DESCRIPTION
**Checklist**
This pull request...

- [X] Fixes a bug
- [ ] Adds new functionality
- [ ] Updates documentation and/or examples
- [ ] Adds tests
- [ ] Is a **breaking** change -- existing code written for this library may need to be rewritten to work after these changes.

**Description**
When handling a user command, look for the user info in the `users` dict if it is not present in the `members` dict. This handles cases where the user is not a member (either they have left the guild or the command is being user in a DM).

**Linked Issue**
Closes #105 
