### PR TITLE
Fix position of kwargs passed to Command() when creating subcommand

### DIFF
--- a/flask_discord_interactions/command.py
+++ b/flask_discord_interactions/command.py
@@ -101,7 +101,11 @@ class Command:
             self.name = command.__name__
 
         if not 1 <= len(self.name) <= 32:
-            raise ValueError(f"Error adding command {self.name}: " "Command name must be between 1 and 32 characters.")
+            raise ValueError(
+                f"Error adding command {self.name}: "
+                "Command name must be between 1 and 32 characters."
+            )
+
         if self.type is ApplicationCommandType.CHAT_INPUT:
             if self.description is None:
                 self.description = command.__doc__ or "No description"
@@ -119,7 +123,8 @@ class Command:
                 )
             if not 1 <= len(self.description) <= 100:
                 raise ValueError(
-                    f"Error adding command {self.name}: " "Command description must be between 1 and 100 characters."
+                    f"Error adding command {self.name}: "
+                    "Command description must be between 1 and 100 characters."
                 )
         else:
             self.description = None
@@ -127,7 +132,9 @@ class Command:
         self.is_async = inspect.iscoroutinefunction(self.command)
 
         if self.options:
-            self.options = [(o.dump() if isinstance(o, Option) else o) for o in self.options]
+            self.options = [
+                (o.dump() if isinstance(o, Option) else o) for o in self.options
+            ]
 
         if self.type is ApplicationCommandType.CHAT_INPUT and self.options is None:
             sig = inspect.signature(self.command)
@@ -173,7 +180,9 @@ class Command:
 
                 option = {
                     "name": parameter.name,
-                    "description": self.annotations.get(parameter.name, "No description"),
+                    "description": self.annotations.get(
+                        parameter.name, "No description"
+                    ),
                     "type": ptype,
                     "required": (parameter.default == parameter.empty),
                     "autocomplete": autocomplete,
@@ -188,7 +197,9 @@ class Command:
                         value_type = str
 
                     for name, member in annotation.__members__.items():
-                        choices.append({"name": name, "value": value_type(member.value)})
+                        choices.append(
+                            {"name": name, "value": value_type(member.value)}
+                        )
 
                     option["choices"] = choices
 
@@ -319,7 +330,14 @@ class SlashCommandSubgroup(Command):
         get an :class:`AsyncContext` instead of a :class:`Context`.)
     """
 
-    def __init__(self, name, description, name_localizations=None, description_localizations=None, is_async=False):
+    def __init__(
+        self,
+        name,
+        description,
+        name_localizations=None,
+        description_localizations=None,
+        is_async=False,
+    ):
         self.name = name
         self.description = description
         self.subcommands = {}
@@ -365,9 +383,14 @@ class SlashCommandSubgroup(Command):
         """
 
         def decorator(func):
-            nonlocal name, description, options, annotations
             subcommand = Command(
-                func, name, description, name_localizations, description_localizations, options, annotations
+                func,
+                name,
+                description,
+                name_localizations=name_localizations,
+                description_localizations=description_localizations,
+                options=options,
+                annotations=annotations,
             )
             self.subcommands[subcommand.name] = subcommand
             return func
@@ -488,6 +511,8 @@ class SlashCommandGroup(SlashCommandSubgroup):
             get an :class:`AsyncContext` instead of a :class:`Context`.)
         """
 
-        group = SlashCommandSubgroup(name, description, name_localizations, description_localizations, is_async)
+        group = SlashCommandSubgroup(
+            name, description, name_localizations, description_localizations, is_async
+        )
         self.subcommands[name] = group
         return group


### PR DESCRIPTION
**Checklist**
This pull request...

- [X] Fixes a bug
- [ ] Adds new functionality
- [ ] Updates documentation and/or examples
- [ ] Adds tests
- [ ] Is a **breaking** change -- existing code written for this library may need to be rewritten to work after these changes.

**Description**
Introducing localization accidentally broke subcommands, as the localization arguments were improperly provided as positional arguments instead of keyword arguments.
