### PR TITLE
Support attachments in the initial response using `multipart/form-data`

### DIFF
--- a/docs/message.rst
+++ b/docs/message.rst
@@ -56,7 +56,7 @@ response ephemeral:
 
 Note that this only works with the initial response, not for followup messages.
 
-For followup messages (*not* the initial response), you can also attach files:
+You can also attach files:
 
 .. code-block:: python
 

--- a/examples/followup.py
+++ b/examples/followup.py
@@ -78,7 +78,8 @@ def delay(ctx, duration: int):
     return Message(deferred=True)
 
 
-# This can be useful if you want to send files
+# This can be useful if you want to send files without worrying about the
+# Discord timeout
 @discord.command()
 def sendfile(ctx):
     def do_sendfile():

--- a/examples/followup.py
+++ b/examples/followup.py
@@ -27,7 +27,7 @@ discord.update_commands()
 
 
 # You can continue to send followup messages from background processes
-# You can also send files now (although you can't with the initial message)
+# You can also send files
 @discord.command()
 def followup(ctx):
     def do_followup():
@@ -42,7 +42,7 @@ def followup(ctx):
         ctx.send(
             Message(
                 content="Sending a file",
-                file=("README.md", open("README.md", "r"), "text/markdown"),
+                file=("README.md", open("README.md", "rb"), "text/markdown"),
             )
         )
         time.sleep(5)

--- a/examples/message_object.py
+++ b/examples/message_object.py
@@ -124,6 +124,15 @@ def ephemeral_embed(ctx):
     )
 
 
+@discord.command()
+def readme(ctx):
+    "Send the content of the readme.md file"
+    return Message(
+        content="Sending a file",
+        file=("README.md", open("README.md", "rb"), "text/markdown"),
+    )
+
+
 discord.set_route("/interactions")
 discord.update_commands(guild_id=os.environ["TESTING_GUILD"])
 

--- a/flask_discord_interactions/context.py
+++ b/flask_discord_interactions/context.py
@@ -408,9 +408,11 @@ class Context(LoadableDataclass):
         if not self.app or self.app.config["DONT_REGISTER_WITH_DISCORD"]:
             return
 
+        response, mimetype = updated.encode(followup=True)
         updated = requests.patch(
             self.followup_url(message),
-            **updated.dump_multipart(),
+            data=response,
+            headers={"Content-Type": mimetype},
         )
         updated.raise_for_status()
 
@@ -446,7 +448,10 @@ class Context(LoadableDataclass):
 
         message = Message.from_return_value(message)
 
-        message = requests.post(self.followup_url(), **message.dump_multipart())
+        response, mimetype = message.encode(followup=True)
+        message = requests.post(
+            self.followup_url(), data=response, headers={"Content-Type": mimetype}
+        )
         message.raise_for_status()
         return message.json()["id"]
 
@@ -553,8 +558,11 @@ class AsyncContext(Context):
         if not self.app or self.app.config["DONT_REGISTER_WITH_DISCORD"]:
             return
 
+        response, mimetype = updated.encode(followup=True)
         await self.session.patch(
-            self.followup_url(message), json=updated.dump_followup()
+            self.followup_url(message),
+            data=response,
+            headers={"Content-Type": mimetype},
         )
 
     async def delete(self, message="@original"):
@@ -588,8 +596,11 @@ class AsyncContext(Context):
         if not self.app or self.app.config["DONT_REGISTER_WITH_DISCORD"]:
             return
 
+        response, mimetype = message.encode(followup=True)
         async with self.session.post(
-            self.followup_url(), **message.dump_multipart()
+            self.followup_url(),
+            data=response,
+            headers={"Content-Type": mimetype},
         ) as message:
             return (await message.json())["id"]
 

--- a/flask_discord_interactions/discord.py
+++ b/flask_discord_interactions/discord.py
@@ -7,7 +7,7 @@ import warnings
 
 import requests
 
-from flask import current_app, request, jsonify, abort
+from flask import Response, current_app, request, jsonify, abort
 
 from nacl.exceptions import BadSignatureError
 from nacl.signing import VerifyKey
@@ -620,6 +620,29 @@ class DiscordInteractions(DiscordInteractionsBlueprint):
         if not request.json:
             abort(400, "Request JSON required")
 
+    def handle_request(self):
+        """
+        Verify the signature in the incoming request and return the Message
+        result from the given command.
+        """
+        self.verify_signature(request)
+
+        interaction_type = request.json.get("type")
+        if interaction_type == InteractionType.PING:
+            abort(jsonify({"type": ResponseType.PONG}))
+        elif interaction_type == InteractionType.APPLICATION_COMMAND:
+            return self.run_command(request.json)
+        elif interaction_type == InteractionType.MESSAGE_COMPONENT:
+            return self.run_handler(request.json)
+        elif interaction_type == InteractionType.APPLICATION_COMMAND_AUTOCOMPLETE:
+            return self.run_autocomplete(request.json)
+        elif interaction_type == InteractionType.MODAL_SUBMIT:
+            return self.run_handler(request.json, allow_modal=False)
+        else:
+            raise RuntimeWarning(
+                f"Interaction type {interaction_type} is not yet supported"
+            )
+
     def set_route(self, route, app=None):
         """
         Add a route handler to the Flask app that handles incoming
@@ -641,30 +664,9 @@ class DiscordInteractions(DiscordInteractionsBlueprint):
 
         @app.route(route, methods=["POST"])
         def interactions():
-            self.verify_signature(request)
-
-            interaction_type = request.json.get("type")
-            if interaction_type == InteractionType.PING:
-                return jsonify({"type": ResponseType.PONG})
-
-            elif interaction_type == InteractionType.APPLICATION_COMMAND:
-                return jsonify(self.run_command(request.json).dump())
-
-            elif interaction_type == InteractionType.MESSAGE_COMPONENT:
-                return jsonify(self.run_handler(request.json).dump_handler())
-
-            elif interaction_type == InteractionType.APPLICATION_COMMAND_AUTOCOMPLETE:
-                return jsonify(self.run_autocomplete(request.json).dump())
-
-            elif interaction_type == InteractionType.MODAL_SUBMIT:
-                return jsonify(
-                    self.run_handler(request.json, allow_modal=False).dump_handler()
-                )
-
-            else:
-                raise RuntimeWarning(
-                    f"Interaction type {interaction_type} is not yet supported"
-                )
+            result = self.handle_request()
+            response, mimetype = result.encode()
+            return Response(response, mimetype=mimetype)
 
     def set_route_async(self, route, app=None):
         """
@@ -692,31 +694,13 @@ class DiscordInteractions(DiscordInteractionsBlueprint):
 
         @app.route(route, methods=["POST"])
         async def interactions():
-            self.verify_signature(request)
-
-            interaction_type = request.json.get("type")
-            if interaction_type == InteractionType.PING:
-                return jsonify({"type": ResponseType.PONG})
-
-            elif interaction_type == InteractionType.APPLICATION_COMMAND:
-                result = self.run_command(request.json)
-            elif interaction_type == InteractionType.MESSAGE_COMPONENT:
-                result = self.run_handler(request.json)
-            elif interaction_type == InteractionType.APPLICATION_COMMAND_AUTOCOMPLETE:
-                result = self.run_autocomplete(request.json)
-
-            elif interaction_type == InteractionType.MODAL_SUBMIT:
-                result = self.run_handler(request.json, allow_modal=False)
-
-            else:
-                raise RuntimeWarning(
-                    f"Interaction type {interaction_type} is not yet supported"
-                )
+            result = self.handle_request()
 
             if inspect.isawaitable(result):
                 result = await result
 
-            return jsonify(result.dump())
+            response, mimetype = result.encode()
+            return Response(response, mimetype=mimetype)
 
         # Set up the aiohttp ClientSession
 

--- a/flask_discord_interactions/models/message.py
+++ b/flask_discord_interactions/models/message.py
@@ -167,7 +167,13 @@ class Message(LoadableDataclass):
 
     def encode(self, followup=False):
         """
-        Return this ``Message`` as a string/mimetype pair.
+        Return this ``Message`` as a string/mimetype pair for sending to Discord.
+
+        If the message contains no files, the string will be a serialized
+        JSON object and the mimetype will be ``application/json``.
+
+        If the message contains attachments, the string will be a multipart
+        encoded response and the mimetype will be ``multipart/form-data``.
 
         Parameters
         ----------

--- a/flask_discord_interactions/models/modal.py
+++ b/flask_discord_interactions/models/modal.py
@@ -1,3 +1,5 @@
+import json
+
 from dataclasses import dataclass
 from typing import List, Union
 
@@ -59,12 +61,12 @@ class Modal(LoadableDataclass):
         "Returns the message components as a list of dicts."
         return [c.dump() for c in self.components]
 
-    def dump(self):
+    def encode(self, followup=False):
         """
         Return this ``Modal`` as a dict to be sent in response to an
         incoming webhook.
         """
-        return {
+        payload = {
             "type": ResponseType.MODAL,
             "data": {
                 "custom_id": self.custom_id,
@@ -73,6 +75,4 @@ class Modal(LoadableDataclass):
             },
         }
 
-    def dump_handler(self):
-        "Return a modal in component handlers."
-        return self.dump()
+        return (json.dumps(payload), "application/json")

--- a/flask_discord_interactions/tests/test_component.py
+++ b/flask_discord_interactions/tests/test_component.py
@@ -1,3 +1,5 @@
+import json
+
 from flask_discord_interactions import (
     Message,
     ResponseType,
@@ -38,7 +40,9 @@ def test_action_row(discord, client):
         },
     }
 
-    assert client.run("action_row").dump() == expected
+    result, mimetype = client.run("action_row").encode()
+    assert json.loads(result) == expected
+    assert mimetype == "application/json"
 
 
 def test_button(discord, client):
@@ -84,7 +88,9 @@ def test_button(discord, client):
         },
     }
 
-    assert client.run("button").dump() == expected
+    result, mimetype = client.run("button").encode()
+    assert json.loads(result) == expected
+    assert mimetype == "application/json"
 
 
 def test_select_menu(discord, client):
@@ -146,4 +152,6 @@ def test_select_menu(discord, client):
         },
     }
 
-    assert client.run("selectmenu").dump() == expected
+    result, mimetype = client.run("selectmenu").encode()
+    assert json.loads(result) == expected
+    assert mimetype == "application/json"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 flask
 requests
+requests-toolbelt
 pynacl

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     zip_safe=False,
     include_package_data=True,
     platforms="any",
-    install_requires=["Flask", "requests", "PyNaCl"],
+    install_requires=["Flask", "requests", "PyNaCl", "requests-toolbelt"],
     extras_require={"async": ["Quart", "aiohttp"]},
     tests_require=["pytest"],
     classifiers=[


### PR DESCRIPTION
**Checklist**
This pull request...

- [ ] Fixes a bug
- [X] Adds new functionality
- [X] Updates documentation and/or examples
- [ ] Adds tests
- [ ] Is a **breaking** change -- existing code written for this library may need to be rewritten to work after these changes.

**Description**
Replace the old `.dump_...()` methods on Message and Modal with a single `.encode()` method which can return either JSON or multipart data.

- [x] Documentation needs to be added
- [x] Tests need to be updated

Closes #104 
