### PR TITLE
implement min_length and max_length

### DIFF
--- a/examples/options.py
+++ b/examples/options.py
@@ -190,7 +190,12 @@ def hexdump(ctx, attachment: Attachment):
 @discord.command(
     options=[
         Option(
-            name="message", type=str, description="The message to repeat", required=True
+            name="message",
+            type=str,
+            description="The message to repeat",
+            required=True,
+            min_length=2,
+            max_length=8,
         ),
         Option(
             name="times",

--- a/flask_discord_interactions/models/option.py
+++ b/flask_discord_interactions/models/option.py
@@ -49,6 +49,10 @@ class Option:
         The minimum value of the option if the option is numeric.
     max_value
         The maximum value of the option if the option is numeric.
+    min_length
+        Minimum allowed length for string type options.
+    max_value
+        Maximum allowed length for string type options.
     autocomplete
         Whether the option should be autocompleted. Defaults to ``False``.
         Set to ``True`` if you have an autocomplete handler for this command.
@@ -71,6 +75,8 @@ class Option:
     channel_types: Optional[list] = None
     min_value: Optional[int] = None
     max_value: Optional[int] = None
+    min_length: Optional[int] = None
+    max_length: Optional[int] = None
     name_localizations: Optional[dict] = None
     description_localizations: Optional[dict] = None
 
@@ -121,6 +127,8 @@ class Option:
             "channel_types": self.channel_types,
             "min_value": self.min_value,
             "max_value": self.max_value,
+            "min_length": self.min_length,
+            "max_length": self.max_length,
             "autocomplete": self.autocomplete,
         }
         if self.choices is not None:


### PR DESCRIPTION
**Checklist**
This pull request...

- [ ] Fixes a bug
- [x] Adds new functionality
- [ ] Updates documentation and/or examples
- [ ] Adds tests
- [ ] Is a **breaking** change -- existing code written for this library may need to be rewritten to work after these changes.

**Description**
Implements min_length and max_length for options, allowing to specify the required length of a string input.

![image](https://user-images.githubusercontent.com/72568063/178206958-a4c6cfe1-6401-4ca0-a61c-f6751e17bfa5.png)

