### PR TITLE
Fix error 400 bad request when application is in team

### DIFF
--- a/docs/botsetup.rst
+++ b/docs/botsetup.rst
@@ -110,6 +110,19 @@ You need to provide Discord with your public URL so they can send you interactio
 
 Click the "Save Changes" box at the bottom. Note that if your bot is not configured properly, the Developer Portal will not allow you to save the URL.
 
+If your application is in a team
+--------------------------------
+
+When your app is in a team you can't use the ``applications.commands.permissions.update`` scope, team applications are limited to the ``identify`` and ``applications.commands.update`` scopes, because teams are not bound to a specific user.
+https://discord.com/developers/docs/topics/oauth2#client-credentials-grant
+
+You can override scopes with
+
+.. code-block:: python
+
+        app.config["DISCORD_SCOPE"] = "applications.commands.update"
+
+
 That's all!
 -----------
 

--- a/flask_discord_interactions/discord.py
+++ b/flask_discord_interactions/discord.py
@@ -324,6 +324,7 @@ class DiscordInteractions(DiscordInteractionsBlueprint):
         app.config.setdefault("DISCORD_CLIENT_ID", "")
         app.config.setdefault("DISCORD_PUBLIC_KEY", "")
         app.config.setdefault("DISCORD_CLIENT_SECRET", "")
+        app.config.setdefault("DISCORD_SCOPE", "applications.commands.update applications.commands.permissions.update")
         app.config.setdefault("DONT_VALIDATE_SIGNATURE", False)
         app.config.setdefault("DONT_REGISTER_WITH_DISCORD", False)
         app.discord_commands = self.discord_commands
@@ -349,7 +350,7 @@ class DiscordInteractions(DiscordInteractionsBlueprint):
         if app.config["DONT_REGISTER_WITH_DISCORD"]:
             app.discord_token = {
                 "token_type": "Bearer",
-                "scope": "applications.commands.update applications.commands.permissions.update",
+                "scope": app.config["DISCORD_SCOPE"],
                 "expires_in": 604800,
                 "access_token": "DONT_REGISTER_WITH_DISCORD",
             }
@@ -361,7 +362,7 @@ class DiscordInteractions(DiscordInteractionsBlueprint):
             app.config["DISCORD_BASE_URL"] + "/oauth2/token",
             data={
                 "grant_type": "client_credentials",
-                "scope": "applications.commands.update applications.commands.permissions.update",
+                "scope": app.config["DISCORD_SCOPE"],
             },
             headers={"Content-Type": "application/x-www-form-urlencoded"},
             auth=(app.config["DISCORD_CLIENT_ID"], app.config["DISCORD_CLIENT_SECRET"]),


### PR DESCRIPTION
**Checklist**
This pull request...

- [x] Fixes a bug
- [ ] Adds new functionality
- [x] Updates documentation and/or examples
- [ ] Adds tests
- [ ] Is a **breaking** change -- existing code written for this library may need to be rewritten to work after these changes.

**Description**

![unknown](https://user-images.githubusercontent.com/11821952/180222616-c0d63517-c7cd-47b4-b7e7-c53521502178.png)

When an application is in team we can't use the `applications.commands.permissions.update` scope and get a error 400, I have added an easy way to fix this issue with a config

[https://discord.com/developers/docs/topics/oauth2#client-credentials-grant](https://discord.com/developers/docs/topics/oauth2#client-credentials-grant)
<img width="890" alt="image" src="https://user-images.githubusercontent.com/11821952/180224324-3519659a-ddcd-4e18-b44a-c8b215b4b3c7.png">
