### PR TITLE
Bump api version to v10

### DIFF
--- a/flask_discord_interactions/discord.py
+++ b/flask_discord_interactions/discord.py
@@ -320,7 +320,7 @@ class DiscordInteractions(DiscordInteractionsBlueprint):
             The Flask app to initialize.
         """
 
-        app.config.setdefault("DISCORD_BASE_URL", "https://discord.com/api/v9")
+        app.config.setdefault("DISCORD_BASE_URL", "https://discord.com/api/v10")
         app.config.setdefault("DISCORD_CLIENT_ID", "")
         app.config.setdefault("DISCORD_PUBLIC_KEY", "")
         app.config.setdefault("DISCORD_CLIENT_SECRET", "")


### PR DESCRIPTION
**Checklist**
This pull request...

- [ ] Fixes a bug
- [ ] Adds new functionality
- [ ] Updates documentation and/or examples
- [ ] Adds tests
- [ ] Is a **breaking** change -- existing code written for this library may need to be rewritten to work after these changes.

**Description**
Probably another 2.0 thing. A good time ago discord introduced api v10 and it will become the default version in about a month.
Ideally nothing should break, the only thing that could be remotely affected is the attachment stuff in #110.
