### PR TITLE
Remove redundant multipart decoding

### DIFF
--- a/flask_discord_interactions/models/message.py
+++ b/flask_discord_interactions/models/message.py
@@ -206,8 +206,8 @@ class Message(LoadableDataclass):
 
         Returns
         -------
-        string
-            A string containing the message data (either JSON or multipart).
+        bytes
+            Bytes containing the message data (either JSON or multipart).
         string
             The mimetype of the message data.
         """
@@ -243,4 +243,4 @@ class Message(LoadableDataclass):
 
             return (multipart.to_string(), multipart.content_type)
         else:
-            return (payload_json, "application/json")
+            return (payload_json.encode("utf-8"), "application/json")

--- a/flask_discord_interactions/models/message.py
+++ b/flask_discord_interactions/models/message.py
@@ -241,6 +241,6 @@ class Message(LoadableDataclass):
                 fields=fields,
             )
 
-            return (multipart.to_string().decode(), multipart.content_type)
+            return (multipart, multipart.content_type)
         else:
             return (payload_json, "application/json")

--- a/flask_discord_interactions/models/message.py
+++ b/flask_discord_interactions/models/message.py
@@ -241,6 +241,6 @@ class Message(LoadableDataclass):
                 fields=fields,
             )
 
-            return (multipart, multipart.content_type)
+            return (multipart.to_string(), multipart.content_type)
         else:
             return (payload_json, "application/json")


### PR DESCRIPTION
**Checklist**
This pull request...

- [x] Fixes a bug
- [ ] Adds new functionality
- [ ] Updates documentation and/or examples
- [ ] Adds tests
- [ ] Is a **breaking** change -- existing code written for this library may need to be rewritten to work after these changes.

**Description**
Doing `.to_string().decode()` will work for text documents, but will break e.g. audio files with an error like:
```UnicodeDecodeError: 'utf-8' codec can't decode byte 0xff in position 466: invalid start byte```

From what research I could do, it looks there there is no encoding/decoding in the example code found at the [requests_toolbelt docs](https://pypi.org/project/requests-toolbelt/), and POST/PATCH `data` in `requests` is expecting a MultipartEncocer object.

I tested this change with file upload code in `examples/followup.py` using both audio and text files.